### PR TITLE
Fixed function prototype for Cache exists

### DIFF
--- a/src/Gaufrette/Filesystem/Adapter/Cache.php
+++ b/src/Gaufrette/Filesystem/Adapter/Cache.php
@@ -81,7 +81,7 @@ class Cache implements Adapter
     /**
      * {@InheritDoc}
      */
-    public function exists()
+    public function exists($key)
     {
         return $this->source->exists($key);
     }


### PR DESCRIPTION
The exists function in the Cache adapter is missing the $key argument.
