### PR TITLE
Use Amazon AWS PHP SDK instead of Zend2 libraries

### DIFF
--- a/src/Gaufrette/Adapter/AmazonS3.php
+++ b/src/Gaufrette/Adapter/AmazonS3.php
@@ -3,7 +3,6 @@
 namespace Gaufrette\Adapter;
 
 use Gaufrette\Adapter;
-use Zend\Service\Amazon\S3\S3;
 
 /**
  * Amazon S3 adapter
@@ -18,7 +17,7 @@ class AmazonS3 implements Adapter
     protected $ensureBucket = false;
     protected $create;
 
-    public function __construct(S3 $service, $bucket, $create = false)
+    public function __construct(\AmazonS3 $service, $bucket, $create = false)
     {
         $this->service = $service;
         $this->bucket = $bucket;
@@ -32,7 +31,12 @@ class AmazonS3 implements Adapter
     {
         $this->ensureBucketExists();
 
-        return $this->service->getObject($this->computePath($key));
+        $response = $this->service->get_object($this->bucket, $key);
+        if (!$response->isOK()) {
+            throw new \RuntimeException(sprintf('Could not read the \'%s\' file.', $key));
+        }
+        
+        return $response->body;
     }
 
     /**
@@ -40,7 +44,21 @@ class AmazonS3 implements Adapter
      */
     public function rename($key, $new)
     {
-        $this->write($new, $this->read($key));
+        $source = array(
+            "bucket" => $this->bucket,
+            "filename" => $key,
+        );
+        
+        $destination = array(
+            "bucket" => $this->bucket,
+            "filename" => $new,
+        );
+        
+        $response = $this->service->copy_object($source, $destination);
+        if (!$response->isOK()) {
+            throw new \RuntimeException(sprintf('Could not rename the \'%s\' file.', $key));
+        }
+        
         $this->delete($key);
     }
 
@@ -50,12 +68,14 @@ class AmazonS3 implements Adapter
     public function write($key, $content)
     {
         $this->ensureBucketExists();
-
-        if (!$this->service->putObject($this->computePath($key), $content)) {
+        
+        $opt = array("body" => $content);
+        $response = $this->service->create_object($this->bucket, $key, $opt);
+        if (!$response->isOK()) {
             throw new \RuntimeException(sprintf('Could not write the \'%s\' file.', $key));
         }
 
-        return $this->getStringNumBytes($content);
+        return intval($response->header["x-aws-requestheaders"]["Content-Length"]);
     }
 
     /**
@@ -65,7 +85,7 @@ class AmazonS3 implements Adapter
     {
         $this->ensureBucketExists();
 
-        return $this->service->isObjectAvailable($this->computePath($key));
+        return $this->service->if_object_exists($this->bucket, $key);
     }
 
     /**
@@ -73,11 +93,8 @@ class AmazonS3 implements Adapter
      */
     public function mtime($key)
     {
-        $this->ensureBucketExists();
-
-        $info = $this->service->getInfo($this->computePath($key));
-
-        return $info['mtime'];
+        $headers = $this->getHeaders($key);
+        return strtotime($headers['Last-modified']);
     }
 
     /**
@@ -85,11 +102,26 @@ class AmazonS3 implements Adapter
      */
     public function checksum($key)
     {
+        $headers = $this->getHeaders($key);
+        return strtotime($headers['etag']);
+    }
+    
+    /**
+     * Fetch the headers of an object
+     * 
+     * @param type $key Object of which to get the headers
+     * @return type array Object headers
+     */
+    protected function getHeaders($key)
+    {
         $this->ensureBucketExists();
-
-        $info = $this->service->getInfo($this->computePath($key));
-
-        return trim($info['etag'], '"');
+        $response = $this->service->get_object_metadata($this->bucket, $key);
+        
+        if ($response === false) {
+            throw new \RuntimeException(sprintf('The \'%s\' file does not exist.', $key));
+        }
+        
+        return $response["Headers"];
     }
 
     /**
@@ -99,7 +131,17 @@ class AmazonS3 implements Adapter
     {
         $this->ensureBucketExists();
 
-        return $this->service->getObjectsByBucket($this->bucket);
+        $response = $this->service->list_objects($this->bucket);
+        if (!$response->isOK()) {
+            throw new \RuntimeException(sprintf('Could not get the keys.', $key));
+        }
+        
+        $keys = array();
+        foreach ($response->body->Contents as $object) {
+            $keys[] = $object->Key->to_string();
+        }
+        
+        return $keys;
     }
 
     /**
@@ -108,19 +150,18 @@ class AmazonS3 implements Adapter
     public function delete($key)
     {
         $this->ensureBucketExists();
-
-        if (!$this->removeObject($this->computePath($key))) {
+        
+        $response = $this->service->delete_object($this->bucket, $key);
+        if (!$response->isOK()) {
             throw new \RuntimeException(sprintf('Could not delete the \'%s\' file.', $key));
         }
+
     }
 
     /**
      * Ensures the specified bucket exists. If the bucket does not exists
      * and the create parameter is set to true, it will try to create the
      * bucket
-     *
-     * @param  string  $bucket The name of the bucket
-     * @param  boolean $create Whether to create the bucket
      *
      * @throws RuntimeException if the bucket does not exists or could not be
      *                          created
@@ -129,10 +170,11 @@ class AmazonS3 implements Adapter
     {
         if (!$this->ensureBucket) {
 
-            $available = $this->service->isBucketAvailable($this->bucket);
+            $available = $this->service->if_bucket_exists($this->bucket);
 
             if (!$available && $this->create) {
-                $created = $this->service->createBucket($this->bucket);
+                $response = $this->service->createBucket($this->bucket, \AmazonS3::REGION_US_E1);
+                $created = $response->isOK();
                 if (!$created) {
                     throw new \RuntimeException(sprintf('Could not create the \'%s\' bucket.', $this->bucket));
                 }
@@ -168,47 +210,5 @@ class AmazonS3 implements Adapter
         }
 
         return ltrim(substr($path, strlen($this->bucket)), '/');
-    }
-
-    /**
-     * Returns the number of bytes of the given string
-     *
-     * @param  string $string
-     *
-     * @return integer
-     */
-    protected function getStringNumBytes($string)
-    {
-        $d = 0;
-        $strlen_var = strlen($string);
-        for ($c = 0; $c < $strlen_var; ++$c) {
-
-            $ord_var_c = ord($string{$d});
-
-            switch (true) {
-                case (($ord_var_c >= 0x20) && ($ord_var_c <= 0x7F)):
-                    $d++;
-                    break;
-                case (($ord_var_c & 0xE0) == 0xC0):
-                    $d+=2;
-                    break;
-                case (($ord_var_c & 0xF0) == 0xE0):
-                    $d+=3;
-                    break;
-                case (($ord_var_c & 0xF8) == 0xF0):
-                    $d+=4;
-                    break;
-                case (($ord_var_c & 0xFC) == 0xF8):
-                    $d+=5;
-                    break;
-                case (($ord_var_c & 0xFE) == 0xFC):
-                    $d+=6;
-                    break;
-                default:
-                    $d++;
-            }
-        }
-
-        return $d;
     }
 }


### PR DESCRIPTION
Using the Amazon AWS PHP SDK instead of the Zend2 libraries has several advantages:
- Use the most up-to-date library : Amazon is maintaining itself the SDK and update the code every time the API change (quite often): see commits https://github.com/amazonwebservices/aws-sdk-for-php/commits/master
- The ZF2's Amazon S3 library is currently broken (see issue #11)
- No need to add the entire Zend framework for just an AWS client (especially if using another PHP framework)

To be done:
- update tests (`bootstrap.php` and `AmazonS3Test.php`)
- add documentation to explain how to include the SDK in a PHP project and how to deal with SSL certificates (needed to talk to S3 servers in HTTPS)
