### PR TITLE
Define variable before testing it

### DIFF
--- a/src/Gaufrette/Filesystem.php
+++ b/src/Gaufrette/Filesystem.php
@@ -140,6 +140,8 @@ class Filesystem
      */
     public function listDirectory($directory = '')
     {
+        $listing = null;
+        
         if (method_exists($this->adapter, 'listDirectory')) {
             $listing = $this->adapter->listDirectory($directory);
         }


### PR DESCRIPTION
If the adapter has no method `listDirectory`, variable `$listing` is undefined and next test crashes :

```
[ErrorException]                                                                                                             
  Notice: Undefined variable: listing in /path/to/vendor/gaufrette/src/Gaufrette/Filesystem.php line 150
```
