### PR TITLE
Fix Ftp::exists method

### DIFF
--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -122,7 +122,7 @@ class Ftp extends Base
 
             $items = ftp_nlist($this->getConnection(), dirname($file));
             foreach ($items as $item) {
-                if ($file === $item) {
+                if (basename($file) === $item) {
                     return true;
                 }
             }


### PR DESCRIPTION
Files returned by "ftp_nlist" were compared to the complete file path, so it never matched.
