### PR TITLE
The current AWS-SDK gives the property lower case

### DIFF
--- a/src/Gaufrette/Adapter/AmazonS3.php
+++ b/src/Gaufrette/Adapter/AmazonS3.php
@@ -151,7 +151,7 @@ class AmazonS3 extends Base
 
         $headers = $this->getHeaders($key);
 
-        return strtotime($headers['Last-modified']);
+        return strtotime($headers['last-modified']);
     }
 
     /**


### PR DESCRIPTION
The implementation of mime() does not work as the current AWS-SDK gives the property in lower case
