### PR TITLE
Typo in RackspaceCloudfiles::tryGetObject.

### DIFF
--- a/src/Gaufrette/Adapter/RackspaceCloudfiles.php
+++ b/src/Gaufrette/Adapter/RackspaceCloudfiles.php
@@ -129,7 +129,7 @@ class RackspaceCloudfiles extends Base
     protected function tryGetObject($key)
     {
         try {
-            return $this->container->getObject($key);
+            return $this->container->get_object($key);
         } catch (\NoSuchObjectException $e) {
             // the NoSuchObjectException is thrown by the CF_Object during it's
             // creation if the object doesn't exist


### PR DESCRIPTION
Fatal error: Call to undefined method CF_Container::getObject().
