### PR TITLE
[S3] Added an overwriteMetadata() function.

### DIFF
--- a/src/Gaufrette/Adapter/AmazonS3.php
+++ b/src/Gaufrette/Adapter/AmazonS3.php
@@ -299,4 +299,36 @@ class AmazonS3 extends Base
     {
         return false;
     }
+    
+    /**
+     * Overwrites the current metadata of an object.
+     * 
+     * @param type $key
+     * @param array $metadata 
+     */
+    public function overwriteMetadata($key, array $metadata){
+    
+        // Check that the bucket we are writing to actually exists
+        // Check that the object actually exsits
+        if($this->exists($key)){
+            
+            // Compute the path of the object (S3 does not really have "folders")
+            $key = $this->prependBaseDirectory($key);
+        
+            // Specify that we want to override metadata
+            $metadata['metadataDirective'] = 'REPLACE';
+            
+            // Perform the operation.
+            $response = $this->service->copy_object(
+                array('bucket' => $this->bucket, 'filename' => $key), 
+                array('bucket' => $this->bucket, 'filename' => $key), 
+                $metadata
+            );
+            if (!$response->isOK()) {
+                throw new \RuntimeException(sprintf('Could not update metadata in the \'%s\' file.', $key));
+            }
+        }else{
+            throw new \RuntimeException(sprintf('The \'%s\' file does not exist.', $key));
+        }
+    }
 }


### PR DESCRIPTION
- **Description:** added an overwriteMetadata() function.
- **Side effects:** -
- **Bug fix:** -
- **Feature addition:** yes
- **Backwards compatibility break:** no
- **Bundle tests pass:** -
- **Fixes the following tickets:** #44
- **References the following tickets:** -
- **External references :** -
- **Example use :** integrating it directly in the write() method would have required a BC-break on the API, so the syntax is quite cumbersome :

```
$fileSystem
     ->getAdapter()
     ->overwriteMetadata($targetFileName,array(
        'acl' => \AmazonS3::ACL_PUBLIC,
        'contentType' => 'application/javascript; charset=utf-8',
        'headers' => array(
            'Content-Type' => 'application/javascript; charset=utf-8',
        ),
        'meta' => array(
            'Content-Type' => 'application/javascript; charset=utf-8',
        ),
        'storage' => \AmazonS3::STORAGE_REDUCED,
));
```
