### PR TITLE
Added the ability to set Cache-Control headers when using the AmazonS3

### DIFF
--- a/src/Gaufrette/Adapter/AmazonS3.php
+++ b/src/Gaufrette/Adapter/AmazonS3.php
@@ -113,6 +113,11 @@ class AmazonS3 extends Base
                     continue;
                 }
 
+                if ('cache-control' === $lk) {
+                    $opt['headers']['Cache-Control'] = $v;
+                    continue;
+                }
+
                 if ('content-encoding' === $lk) {
                     $opt['headers']['Content-Encoding'] = $v;
                     continue;


### PR DESCRIPTION
Currently, setting 'cache-control' metadata will result in a x-amz-meta-cache-control metadata key being set. This addition allows correctly setting Cache-Control headers.
