### PR TITLE
PR to resolve issue when reading files via FTP

### DIFF
--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -119,7 +119,7 @@ class Ftp extends Base
 
             $items = ftp_nlist($this->getConnection(), dirname($file));
             foreach ($items as $item) {
-                if (basename($file) === $item) {
+                if (basename($file) === basename($item)) {
                     return true;
                 }
             }


### PR DESCRIPTION
This fixes the same issue addressed  here (https://github.com/KnpLabs/Gaufrette/pull/53) which the author of that PR seems to have abandoned - but in a different way.

I kept the basename() function on both sides of the if statement because the absolute file path on the FTP server and the path being requested via the adapter could be different (when your starting directory for your adapter is not the root).
