### PR TITLE
[Sftp] Better renaming strategy.

### DIFF
--- a/src/Gaufrette/Adapter/Sftp.php
+++ b/src/Gaufrette/Adapter/Sftp.php
@@ -55,10 +55,12 @@ class Sftp extends Base
             throw new Exception\UnexpectedFile($targetKey);
         }
 
-        try {
-            $this->write($targetKey, $this->read($sourceKey));
-            $this->delete($sourceKey);
-        } catch (\RuntimeException $e) {
+        $sourcePath = $this->computePath($sourceKey);
+        $targetPath = $this->computePath($targetKey);
+
+        $this->ensureDirectoryExists(dirname($targetPath), true);
+
+        if(!$this->sftp->rename($sourcePath, $targetPath)) {
             throw new \RuntimeException(sprintf(
                 'Could not rename the "%s" file to "%s".',
                 $sourceKey,


### PR DESCRIPTION
The current renaming stategy for Sftp is to download the whole file, copy its content into a new file and delete the old.

This just doesn't make sense !
- Relying on a client side renaming stategy is much more error prone than using the dedicated sftp command achieving this.
- The atomicity property of this operation should be the matter of the sftp server implementation, that is for sure much better handled than any php extension.
- Renaming a file should be done in constant time. With the current code, renaming a 1B file is much quicker than renaming a 1GB file.

And finally, as you chose to expose an abstract `FIleSystem` that doesn't cope with directory, renaming in a new directory should create that directory.
