### PR TITLE
Add missing use statement (Util class)

### DIFF
--- a/src/Gaufrette/Adapter/RackspaceCloudfiles.php
+++ b/src/Gaufrette/Adapter/RackspaceCloudfiles.php
@@ -3,6 +3,7 @@
 namespace Gaufrette\Adapter;
 
 use CF_Container;
+use Gaufrette\Util;
 
 /**
  * Rackspace cloudfiles adapter


### PR DESCRIPTION
Util is used in class body, but not referenced via use. This edit fixes it.
