### PR TITLE
Fixed Amazon S3 default permission on new files

### DIFF
--- a/src/Gaufrette/Adapter/AmazonS3.php
+++ b/src/Gaufrette/Adapter/AmazonS3.php
@@ -110,13 +110,16 @@ class AmazonS3 extends Base
     public function write($key, $content, array $metadata = null)
     {
         $this->ensureBucketExists();
-
-        $opt = array('body' => $content);
-
+    
+        $opt = array(
+            'body' => $content,
+            'acl'  => \AmazonS3::ACL_PUBLIC
+        );
+    
         $response = $this->service->create_object(
             $this->bucket,
             $this->computePath($key),
-            array('body' => $content)
+            $opt
         );
 
         if (!$response->isOK()) {


### PR DESCRIPTION
To avoid "Access Denied" errors on new files (when not using Amazon ACLs).

The default permission was missing on the current AmazonS3 adapter. If a file has to be private, you need to use the AclAwareAmazonS3 adapter instead of the AmazonS3 one.
