### PR TITLE
use realpath instead of readlink while defining local adapter's base directory

### DIFF
--- a/src/Gaufrette/Adapter/Local.php
+++ b/src/Gaufrette/Adapter/Local.php
@@ -31,7 +31,7 @@ class Local extends Base
         $this->directory = $this->normalizePath($directory);
 
         if (is_link($this->directory)) {
-            $this->directory = readlink($this->directory);
+            $this->directory = realpath($this->directory);
         }
 
         $this->ensureDirectoryExists($this->directory, $create);


### PR DESCRIPTION
Lets consider such example:
we set base directory to '/Users/alex/Sites/test/shared'
which is a symlink to '../anotherTest/shared'.
In case of using readlink function, base local adapter's directory will be
'../anotherTest/shared' and if you try to read file via that adapter you get
`The path is out of the filesystem` error.
In case of using realpath function, the adapter's base directory will be:
'/Users/alex/Sites/anotherTest/shared/' an everything works as expected.
