### PR TITLE
Fix FTP adapter

### DIFF
--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -130,6 +130,7 @@ class Ftp extends Base
         $file  = $this->computePath($key);
         $items = ftp_nlist($this->getConnection(), dirname($file));
 
+        $file = basename($file);
         foreach ($items as $item) {
             if ($file === $item) {
                 return true;


### PR DESCRIPTION
ftp_nlist return value matching must be done with file's base name 
