### PR TITLE
Stream fixes

### DIFF
--- a/src/Gaufrette/FileStream.php
+++ b/src/Gaufrette/FileStream.php
@@ -85,4 +85,18 @@ interface FileStream
      * @return Boolean
      */
     function eof();
+
+    /**
+     * Gathers statistics of the stream
+     *
+     * @return array
+     */
+    function stat();
+
+    /**
+     * Retrieve the underlaying resource
+     *
+     * @param integer $castAs
+     */
+    function cast($castAs);
 }

--- a/src/Gaufrette/FileStream/InMemoryBuffer.php
+++ b/src/Gaufrette/FileStream/InMemoryBuffer.php
@@ -156,4 +156,20 @@ class InMemoryBuffer implements FileStream
     {
         return $this->position >= $this->numBytes;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function stat()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function cast($castAst)
+    {
+        return false;
+    }
 }

--- a/src/Gaufrette/StreamWrapper.php
+++ b/src/Gaufrette/StreamWrapper.php
@@ -85,6 +85,11 @@ class StreamWrapper
         return static::$filesystems[$domain];
     }
 
+    static protected function createFilesystemMap()
+    {
+        return new FilesystemMap();
+    }
+
     public function stream_open($path, $mode)
     {
         $this->stream = $this->createStream($path);
@@ -92,51 +97,112 @@ class StreamWrapper
         return $this->stream->open($this->createStreamMode($mode));
     }
 
-    public function stream_read($count)
+    /**
+     * @param int $bytes
+     * @return mixed
+     */
+    public function stream_read($bytes)
     {
-        return $this->stream->read($count);
+        if ($this->stream) {
+            return $this->stream->read($bytes);
+        }
+
+        return false;
     }
 
+    /**
+     * @param string $data
+     * @return int
+     */
     public function stream_write($data)
     {
-        return $this->stream->write($data);
+        if ($this->stream) {
+            return $this->stream->write($data);
+        }
+
+        return 0;
     }
 
     public function stream_close()
     {
-        $this->stream->close();
+        if ($this->stream) {
+            $this->stream->close();
+        }
     }
 
+    /**
+     * @return boolean
+     */
     public function stream_flush()
     {
-        return $this->stream->flush();
+        if ($this->stream) {
+            return $this->stream->flush();
+        }
+
+        return false;
     }
 
+    /**
+     * @param int $offset
+     * @param int $whence - one of values [SEEK_SET, SEEK_CUR, SEEK_END]
+     * @return boolean
+     */
     public function stream_seek($offset, $whence = SEEK_SET)
     {
-        return $this->stream->seek($offset, $whence);
+        if ($this->stream) {
+            return $this->stream->seek($offset, $whence);
+        }
+
+        return false;
     }
 
+    /**
+     * @return mixed
+     */
     public function stream_tell()
     {
-        return $this->stream->tell();
+        if ($this->stream) {
+            return $this->stream->tell();
+        }
+
+        return false;
     }
 
+    /**
+     * @return boolean
+     */
     public function stream_eof()
     {
-        return $this->stream->eof();
+        if ($this->stream) {
+            return $this->stream->eof();
+        }
+
+        return true;
     }
 
+    /**
+     * @return mixed
+     */
     public function stream_stat()
     {
-        return $this->stream->stat();
+        if ($this->stream) {
+            return $this->stream->stat();
+        }
+
+        return false;
     }
-    
+
+    /**
+     * @param string $path
+     * @param int $flags
+     * @return mixed
+     * @todo handle $flags parameter
+     */
     public function url_stat($path, $flags)
     {
-      $this->stream = $this->createStream($path);
-      
-      return $this->stream_stat();
+        $stream = $this->createStream($path);
+
+        return $stream->stat();
     }
 
     protected function createStream($path)
@@ -176,10 +242,5 @@ class StreamWrapper
     protected function createStreamMode($mode)
     {
         return new StreamMode($mode);
-    }
-
-    static protected function createFilesystemMap()
-    {
-        return new FilesystemMap();
     }
 }

--- a/tests/Gaufrette/FileStream/LocalTest.php
+++ b/tests/Gaufrette/FileStream/LocalTest.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace Gaufrette\FileStream;
+
+use Gaufrette\Filesystem;
+use Gaufrette\Adapter;
+use Gaufrette\StreamMode;
+
+class LocalTest extends \PHPUnit_Framework_TestCase
+{
+    private $filePath;
+
+    public function setUp()
+    {
+        $this->filePath = __DIR__.'localStreamTestFile.txt';
+    }
+
+    public function tearDown()
+    {
+        if (is_file($this->filePath)) {
+            unlink($this->filePath);
+        }
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     * @expectedException \RuntimeException
+     */
+    public function shouldNotBeAbleToOpenFileToReadWhenDoesNotExist()
+    {
+        $stream  = new Local($this->filePath);
+        $this->assertFalse($stream->open(new StreamMode('r')));
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldBeAbleToOpenFileToRead()
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $this->assertTrue($stream->open(new StreamMode('r')));
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldBeAbleToReadFile()
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $stream->open(new StreamMode('r'));
+
+        $this->assertEquals('Some', $stream->read(4));
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldNotFailWhenReadFileWasNotOpen()
+    {
+        $stream  = new Local($this->filePath);
+
+        $this->assertFalse($stream->read(4));
+    }
+
+    /**
+     * @test
+     * @dataProvider getNotReadableModes
+     * @expectedException LogicException
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldFailWhenReadIsNotAllowed($mode)
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $stream->open(new StreamMode($mode));
+        $stream->read(4);
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldBeAbleToWriteFile()
+    {
+        $stream  = new Local($this->filePath);
+        $stream->open(new StreamMode('w'));
+        $stream->write('Other content');
+
+        $this->assertEquals('Other content', file_get_contents($this->filePath));
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldNotFailWhenWriteFileWasNotOpen()
+    {
+        $stream  = new Local($this->filePath);
+
+        $this->assertFalse($stream->write('Other content'));
+    }
+
+    /**
+     * @test
+     * @expectedException LogicException
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldFailWhenWriteIsNotAllowed()
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $stream->open(new StreamMode('r'));
+        $stream->write('Other content');
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldCloseTheFileHandler()
+    {
+        $stream  = new Local($this->filePath);
+        $stream->open(new StreamMode('w'));
+
+        $this->assertTrue($stream->close());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldNotFailWhenClosingFileWasNotOpen()
+    {
+        $stream  = new Local($this->filePath);
+
+        $this->assertFalse($stream->close());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldFlushTheFile()
+    {
+        $stream  = new Local($this->filePath);
+        $stream->open(new StreamMode('w'));
+
+        $this->assertTrue($stream->flush());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldNotFailWhenFlushingFileWasNotOpen()
+    {
+        $stream  = new Local($this->filePath);
+
+        $this->assertFalse($stream->flush());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldSeekInFile()
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $stream->open(new StreamMode('r+'));
+
+        $this->assertTrue($stream->seek(1));
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldNotFailWhenSeekingFileWasNotOpen()
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $this->assertFalse(false, $stream->seek(1));
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldGetCurrentPositionInFileStream()
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $stream->open(new StreamMode('r+'));
+        $stream->seek(3);
+
+        $this->assertEquals(3, $stream->tell());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldNotFailWhenTellingFileWasNotOpen()
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $this->assertFalse($stream->tell());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldCheckEOFInStream()
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $stream->open(new StreamMode('r'));
+        $stream->seek(13);
+        $stream->read(1);
+
+        $this->assertTrue($stream->eof());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldNotFailWhenEOFCheckingFileWasNotOpen()
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $this->assertTrue($stream->eof());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldGetStatFileInfo()
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $stream->open(new StreamMode('w+'));
+
+        $this->assertInternalType('array', $stream->stat());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldNotFailWhenStatingFileWasNotOpen()
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $this->assertFalse($stream->stat());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldCastToResourseType()
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $stream->open(new StreamMode('r+'));
+        $this->assertInternalType('resource', $stream->cast(STREAM_CAST_FOR_SELECT));
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\FileStream\Local
+     */
+    public function shouldNotFailWhenCastingFileWasNotOpen()
+    {
+        file_put_contents($this->filePath, 'Some contents');
+
+        $stream  = new Local($this->filePath);
+        $this->assertFalse($stream->cast(STREAM_CAST_FOR_SELECT));
+    }
+
+    public function getNotReadableModes()
+    {
+        return array(
+            array('w'),
+            array('a'),
+            array('c'),
+        );
+    }
+}

--- a/tests/Gaufrette/StreamWrapperTest.php
+++ b/tests/Gaufrette/StreamWrapperTest.php
@@ -16,8 +16,9 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      * @dataProvider getDataToTestStreamOpenFileKey
+     * @covers Gaufrette\StreamWrapper
      */
-    public function shouldStreamOpenFileKey($domain, $uri, $key)
+    public function shouldOpenStreamForFileKey($domain, $uri, $key)
     {
         $stream = $this->getFileStreamMock();
         $stream
@@ -36,6 +37,403 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
 
         $wrapper = new StreamWrapper();
         $wrapper->stream_open($uri, 'r');
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     * @expectedException \InvalidArgumentException
+     */
+    public function shouldFailWhenTryOpenStreamWithoutDomain()
+    {
+        $wrapper = new StreamWrapper();
+        $wrapper->stream_open('', 'r');
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldReadFromStream()
+    {
+        $stream = $this->getFileStreamMock();
+        $stream
+            ->expects($this->once())
+            ->method('open')
+        ;
+        $stream
+            ->expects($this->once())
+            ->method('read')
+            ->with($this->equalTo(30))
+            ->will($this->returnValue('value from stream'))
+        ;
+
+        $filesystem = $this->getFilesystemMock();
+        $filesystem
+            ->expects($this->once())
+            ->method('createFileStream')
+            ->will($this->returnValue($stream))
+        ;
+
+        $this->filesystemMap->set('foo', $filesystem);
+
+        $wrapper = new StreamWrapper();
+        $wrapper->stream_open('gaufrette://foo/test', 'r');
+        $this->assertSame('value from stream', $wrapper->stream_read(30));
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldNotFailWhenReadingStreamWhichWasNotOpen()
+    {
+        $stream = $this->getFileStreamMock();
+        $filesystem = $this->getFilesystemMock();
+
+        $this->filesystemMap->set('foo', $filesystem);
+
+        $wrapper = new StreamWrapper();
+        $this->assertFalse($wrapper->stream_read(30));
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldWriteToStream()
+    {
+        $stream = $this->getFileStreamMock();
+        $stream
+            ->expects($this->once())
+            ->method('open')
+        ;
+        $stream
+            ->expects($this->once())
+            ->method('write')
+            ->with($this->equalTo('Content to write'))
+            ->will($this->returnValue(12))
+        ;
+
+        $filesystem = $this->getFilesystemMock();
+        $filesystem
+            ->expects($this->once())
+            ->method('createFileStream')
+            ->will($this->returnValue($stream))
+        ;
+
+        $this->filesystemMap->set('foo', $filesystem);
+
+        $wrapper = new StreamWrapper();
+        $wrapper->stream_open('gaufrette://foo/test', 'w');
+        $this->assertSame(12, $wrapper->stream_write('Content to write'));
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldNotFailWhenWriteToStreamWhichWasNotOpen()
+    {
+        $wrapper = new StreamWrapper();
+        $this->assertSame(0, $wrapper->stream_write('Content to write'));
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldCloseStream()
+    {
+        $stream = $this->getFileStreamMock();
+        $stream
+            ->expects($this->once())
+            ->method('open')
+        ;
+        $stream
+            ->expects($this->once())
+            ->method('close')
+        ;
+        $filesystem = $this->getFilesystemMock();
+        $filesystem
+            ->expects($this->once())
+            ->method('createFileStream')
+            ->will($this->returnValue($stream))
+        ;
+
+        $this->filesystemMap->set('foo', $filesystem);
+
+        $wrapper = new StreamWrapper();
+        $wrapper->stream_open('gaufrette://foo/test', 'w');
+        $wrapper->stream_close();
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldNotFailWhenCloseStreamWhichWasNotOpen()
+    {
+        $wrapper = new StreamWrapper();
+        $wrapper->stream_close();
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldFlushStream()
+    {
+        $stream = $this->getFileStreamMock();
+        $stream
+            ->expects($this->once())
+            ->method('open')
+        ;
+        $stream
+            ->expects($this->once())
+            ->method('flush')
+            ->will($this->returnValue(true))
+        ;
+        $filesystem = $this->getFilesystemMock();
+        $filesystem
+            ->expects($this->once())
+            ->method('createFileStream')
+            ->will($this->returnValue($stream))
+        ;
+
+        $this->filesystemMap->set('foo', $filesystem);
+
+        $wrapper = new StreamWrapper();
+        $wrapper->stream_open('gaufrette://foo/test', 'w');
+        $this->assertTrue($wrapper->stream_flush());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldNotFailWhenFlushStreamWhichWasNotOpen()
+    {
+        $wrapper = new StreamWrapper();
+        $this->assertFalse($wrapper->stream_flush());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldSeekPositionInStream()
+    {
+        $stream = $this->getFileStreamMock();
+        $stream
+            ->expects($this->once())
+            ->method('open')
+        ;
+        $stream
+            ->expects($this->once())
+            ->method('seek')
+            ->with($this->equalTo(12), $this->equalTo(SEEK_CUR))
+            ->will($this->returnValue(true))
+        ;
+        $filesystem = $this->getFilesystemMock();
+        $filesystem
+            ->expects($this->once())
+            ->method('createFileStream')
+            ->will($this->returnValue($stream))
+        ;
+
+        $this->filesystemMap->set('foo', $filesystem);
+
+        $wrapper = new StreamWrapper();
+        $wrapper->stream_open('gaufrette://foo/test', 'r');
+        $this->assertTrue($wrapper->stream_seek(12, SEEK_CUR));
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldNotFailWhenSeekPositionInStreamWhichWasNotOpen()
+    {
+        $wrapper = new StreamWrapper();
+        $this->assertFalse($wrapper->stream_seek(12, SEEK_CUR));
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldGetCurrentPositionFromStream()
+    {
+        $stream = $this->getFileStreamMock();
+        $stream
+            ->expects($this->once())
+            ->method('open')
+        ;
+        $stream
+            ->expects($this->once())
+            ->method('tell')
+            ->will($this->returnValue(44))
+        ;
+        $filesystem = $this->getFilesystemMock();
+        $filesystem
+            ->expects($this->once())
+            ->method('createFileStream')
+            ->will($this->returnValue($stream))
+        ;
+
+        $this->filesystemMap->set('foo', $filesystem);
+
+        $wrapper = new StreamWrapper();
+        $wrapper->stream_open('gaufrette://foo/test', 'r');
+        $this->assertEquals(44, $wrapper->stream_tell());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldNotFailWhenGetCurrentPositionFromStreamWhichWasNotOpen()
+    {
+        $wrapper = new StreamWrapper();
+        $this->assertFalse($wrapper->stream_tell());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldCheckEOFInStream()
+    {
+        $stream = $this->getFileStreamMock();
+        $stream
+            ->expects($this->once())
+            ->method('open')
+        ;
+        $stream
+            ->expects($this->once())
+            ->method('eof')
+            ->will($this->returnValue(false))
+        ;
+        $filesystem = $this->getFilesystemMock();
+        $filesystem
+            ->expects($this->once())
+            ->method('createFileStream')
+            ->will($this->returnValue($stream))
+        ;
+
+        $this->filesystemMap->set('foo', $filesystem);
+
+        $wrapper = new StreamWrapper();
+        $wrapper->stream_open('gaufrette://foo/test', 'r');
+        $this->assertFalse($wrapper->stream_eof());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldNotFailWhenCheckEOFInStreamWhichWasNotOpen()
+    {
+        $wrapper = new StreamWrapper();
+        $this->assertTrue($wrapper->stream_eof());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldGetStatInfoFromStream()
+    {
+        $statInfo = array(
+            'dev'   => 1,
+            'ino'   => 12,
+            'mode'  => 0777,
+            'nlink' => 0,
+            'uid'   => 123,
+            'gid'   => 1,
+            'rdev'  => 0,
+            'size'  => 666,
+            'atime' => 1348030800,
+            'mtime' => 1348030800,
+            'ctime' => 1348030800,
+            'blksize' => 5,
+            'blocks'  => 1,
+        );
+
+        $stream = $this->getFileStreamMock();
+        $stream
+            ->expects($this->once())
+            ->method('open')
+        ;
+        $stream
+            ->expects($this->once())
+            ->method('stat')
+            ->will($this->returnValue($statInfo))
+        ;
+        $filesystem = $this->getFilesystemMock();
+        $filesystem
+            ->expects($this->once())
+            ->method('createFileStream')
+            ->will($this->returnValue($stream))
+        ;
+
+        $this->filesystemMap->set('foo', $filesystem);
+
+        $wrapper = new StreamWrapper();
+        $wrapper->stream_open('gaufrette://foo/test', 'r');
+        $this->assertSame($statInfo, $wrapper->stream_stat());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldNotFailWhenGetStatFromStreamWhichWasNotOpen()
+    {
+        $wrapper = new StreamWrapper();
+        $this->assertFalse($wrapper->stream_stat());
+    }
+
+    /**
+     * @test
+     * @covers Gaufrette\StreamWrapper
+     */
+    public function shouldGetUrlStatInfoFromStream()
+    {
+        $statInfo = array(
+            'dev'   => 1,
+            'ino'   => 12,
+            'mode'  => 0777,
+            'nlink' => 0,
+            'uid'   => 123,
+            'gid'   => 1,
+            'rdev'  => 0,
+            'size'  => 666,
+            'atime' => 1348030800,
+            'mtime' => 1348030800,
+            'ctime' => 1348030800,
+            'blksize' => 5,
+            'blocks'  => 1,
+        );
+
+        $stream = $this->getFileStreamMock();
+        $stream
+            ->expects($this->once())
+            ->method('stat')
+            ->will($this->returnValue($statInfo))
+        ;
+        $filesystem = $this->getFilesystemMock();
+        $filesystem
+            ->expects($this->once())
+            ->method('createFileStream')
+            ->will($this->returnValue($stream))
+        ;
+
+        $this->filesystemMap->set('foo', $filesystem);
+
+        $wrapper = new StreamWrapper();
+        $this->assertSame($statInfo, $wrapper->url_stat('gaufrette://foo/test', STREAM_URL_STAT_LINK));
     }
 
     public function getDataToTestStreamOpenFileKey()


### PR DESCRIPTION
- Added missing StreamWrapper methods (Thanks to @nervo PR)
- Added stat and cast method to FileStream interface which can cause BC break if someone implements this interface in own code. (tag v0.1.1 was created, so IMO its safe to merge to master)

Before those changes stream will not worked with Gaufrette well. 

This should resolve #68 and #84
