### PR TITLE
add support of file metadata while writing to amazon s3

### DIFF
--- a/src/Gaufrette/Adapter/AmazonS3.php
+++ b/src/Gaufrette/Adapter/AmazonS3.php
@@ -108,12 +108,12 @@ class AmazonS3 extends Base
     public function write($key, $content, array $metadata = null)
     {
         $this->ensureBucketExists();
-    
-        $opt = array(
+
+        $opt = array_merge(array(
             'body' => $content,
             'acl'  => \AmazonS3::ACL_PUBLIC
-        );
-    
+        ), (array) $metadata);
+
         $response = $this->service->create_object(
             $this->bucket,
             $this->computePath($key),


### PR DESCRIPTION
This allows to add metadata to the object, while writing to s3, like contentType, override public acl, etc.
