### PR TITLE
Cached the bucket check in the S3 adapter

### DIFF
--- a/src/Gaufrette/Adapter/AmazonS3.php
+++ b/src/Gaufrette/Adapter/AmazonS3.php
@@ -236,7 +236,7 @@ class AmazonS3 extends Base
 
         if ($this->service->if_bucket_exists($this->bucket)) {
             $this->ensureBucket = true;
-            
+
             return;
         }
 


### PR DESCRIPTION
The bucket existence check was cached when the adapter is creating
the bucket, but not when it already exists.
This avoids doing duplicated API calls to check the existence of the
bucket for each method
