### PR TITLE
Skip dots in Ftp-Adapter

### DIFF
--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -175,7 +175,7 @@ class Ftp implements Adapter,
         $fileData = $dirs = array();
         foreach ($items as $itemData) {
             
-            if (strpos($itemData['name'],'.') !== false) {
+            if ('..' === $itemData['name'] || '.' === $itemData['name']) {
                 continue;
             }
             


### PR DESCRIPTION
Skips the current and parent-directories from the file/directory-list.

This was causing infinite recursion when listing ftp-directories.
