### PR TITLE
Add method to get Rackspace Cloudfiles object

### DIFF
--- a/src/Gaufrette/Adapter/RackspaceCloudfiles.php
+++ b/src/Gaufrette/Adapter/RackspaceCloudfiles.php
@@ -137,7 +137,7 @@ class RackspaceCloudfiles implements Adapter,
      *
      * @return CF_Object or FALSE if the object does not exist
      */
-    protected function tryGetObject($key)
+    public function tryGetObject($key)
     {
         try {
             return $this->container->get_object($key);

--- a/src/Gaufrette/Filesystem.php
+++ b/src/Gaufrette/Filesystem.php
@@ -255,4 +255,12 @@ class Filesystem
             throw new Exception\FileNotFound($key);
         }
     }
+
+    /** 
+     * {@inheritDoc}
+     */
+    public function getObject($key)
+    {
+            return $this->adapter->tryGetObject($key);
+    }
 }


### PR DESCRIPTION
The Rackspace Cloudfiles object is needed to get the CDN URL:  $object->public_uri(), and currently there's no way to to this.
