### PR TITLE
implemented fast listKeys for gridfs

### DIFF
--- a/src/Gaufrette/Adapter/GridFS.php
+++ b/src/Gaufrette/Adapter/GridFS.php
@@ -15,7 +15,8 @@ use \MongoDate;
  */
 class GridFS implements Adapter,
                         ChecksumCalculator,
-                        MetadataSupporter
+                        MetadataSupporter,
+                        ListKeysAware
 {
     private $metadata = array();
     protected $gridFS = null;
@@ -147,5 +148,35 @@ class GridFS implements Adapter,
     private function find($key, array $fields = array())
     {
         return $this->gridFS->findOne($key, $fields);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function listKeys($pattern = '')
+    {
+        $pattern = trim($pattern);
+
+        if ('' == $pattern) {
+            return array(
+                'dirs' => array(),
+                'keys' => $this->keys()
+            );
+        }
+
+        $result = array(
+            'dirs' => array(),
+            'keys' => array()
+        );
+
+        $gridFiles = $this->gridFS->find(array(
+            'filename' => new \MongoRegex(sprintf('/^%s/', $pattern))
+        ));
+
+        foreach ($gridFiles as $file) {
+            $result['keys'][] = $file->getFilename();
+        }
+
+        return $result;
     }
 }

--- a/src/Gaufrette/Adapter/ListKeysAware.php
+++ b/src/Gaufrette/Adapter/ListKeysAware.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Gaufrette\Adapter;
+
+/**
+ * interface that adds support of native listKeys to adapter
+ *
+ * @author Andrew Tch <andrew.tchircoff@gmail.com>
+ */
+interface ListKeysAware
+{
+    /**
+     * Lists keys beginning with pattern given
+     * (no wildcard / regex matching)
+     *
+     * @param string $pattern
+     * @return array
+     */
+    public function listKeys($pattern = '');
+}

--- a/src/Gaufrette/Filesystem.php
+++ b/src/Gaufrette/Filesystem.php
@@ -2,6 +2,8 @@
 
 namespace Gaufrette;
 
+use Gaufrette\Adapter\ListKeysAware;
+
 /**
  * A filesystem is used to store and retrieve files
  *
@@ -170,6 +172,10 @@ class Filesystem
      */
     public function listKeys($pattern = '')
     {
+        if ($this->adapter instanceof ListKeysAware) {
+            return $this->adapter->listKeys($pattern);
+        }
+
         $dirs = array();
         $keys = array();
 

--- a/tests/Gaufrette/Functional/Adapter/DoctrineDbalTest.php
+++ b/tests/Gaufrette/Functional/Adapter/DoctrineDbalTest.php
@@ -4,4 +4,53 @@ namespace Gaufrette\Functional\Adapter;
 
 class DoctrineDbalTest extends FunctionalTestCase
 {
+    /**
+    * @test
+    */
+    public function shouldListKeys()
+    {
+        $this->filesystem->write('foo/foobar/bar.txt', 'data');
+        $this->filesystem->write('foo/bar/buzz.txt', 'data');
+        $this->filesystem->write('foobarbuz.txt', 'data');
+        $this->filesystem->write('foo', 'data');
+
+        $allKeys = $this->filesystem->listKeys(' ');
+        //empty pattern results in ->keys call
+        $this->assertEquals(
+            $this->filesystem->keys(),
+            $allKeys['keys']
+        );
+
+        //these values are canonicalized to avoid wrong order or keys issue
+
+        $keys = $this->filesystem->listKeys('foo');
+        $this->assertEquals(
+            $this->filesystem->keys(),
+            $keys['keys'],
+            '', 0, 10, true);
+
+        $keys = $this->filesystem->listKeys('foo/foob');
+        $this->assertEquals(
+            array('foo/foobar/bar.txt'),
+            $keys['keys'],
+            '', 0, 10, true);
+
+        $keys = $this->filesystem->listKeys('foo/');
+        $this->assertEquals(
+            array('foo/foobar/bar.txt', 'foo/bar/buzz.txt'),
+            $keys['keys'],
+            '', 0, 10, true);
+
+        $keys = $this->filesystem->listKeys('foo');
+        $this->assertEquals(
+            array('foo/foobar/bar.txt', 'foo/bar/buzz.txt', 'foobarbuz.txt', 'foo'),
+            $keys['keys'],
+            '', 0, 10, true);
+
+        $keys = $this->filesystem->listKeys('fooz');
+        $this->assertEquals(
+            array(),
+            $keys['keys'],
+            '', 0, 10, true);
+    }
 }

--- a/tests/Gaufrette/Functional/Adapter/FunctionalTestCase.php
+++ b/tests/Gaufrette/Functional/Adapter/FunctionalTestCase.php
@@ -6,6 +6,9 @@ use Gaufrette\Filesystem;
 
 abstract class FunctionalTestCase extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Filesystem
+     */
     protected $filesystem;
 
     public function getAdapterName()

--- a/tests/Gaufrette/Functional/Adapter/GridFSTest.php
+++ b/tests/Gaufrette/Functional/Adapter/GridFSTest.php
@@ -6,4 +6,53 @@ use Gaufrette\Adapter\GridFS;
 
 class GridFSTest extends FunctionalTestCase
 {
+    /**
+     * @test
+     */
+    public function shouldListKeys()
+    {
+        $this->filesystem->write('foo/foobar/bar.txt', 'data');
+        $this->filesystem->write('foo/bar/buzz.txt', 'data');
+        $this->filesystem->write('foobarbuz.txt', 'data');
+        $this->filesystem->write('foo', 'data');
+
+        $allKeys = $this->filesystem->listKeys(' ');
+        //empty pattern results in ->keys call
+        $this->assertEquals(
+            $this->filesystem->keys(),
+            $allKeys['keys']
+        );
+
+        //these values are canonicalized to avoid wrong order or keys issue
+
+        $keys = $this->filesystem->listKeys('foo');
+        $this->assertEquals(
+            $this->filesystem->keys(),
+            $keys['keys'],
+            '', 0, 10, true);
+
+        $keys = $this->filesystem->listKeys('foo/foob');
+        $this->assertEquals(
+            array('foo/foobar/bar.txt'),
+            $keys['keys'],
+            '', 0, 10, true);
+
+        $keys = $this->filesystem->listKeys('foo/');
+        $this->assertEquals(
+            array('foo/foobar/bar.txt', 'foo/bar/buzz.txt'),
+            $keys['keys'],
+            '', 0, 10, true);
+
+        $keys = $this->filesystem->listKeys('foo');
+        $this->assertEquals(
+            array('foo/foobar/bar.txt', 'foo/bar/buzz.txt', 'foobarbuz.txt', 'foo'),
+            $keys['keys'],
+            '', 0, 10, true);
+
+        $keys = $this->filesystem->listKeys('fooz');
+        $this->assertEquals(
+            array(),
+            $keys['keys'],
+            '', 0, 10, true);
+    }
 }


### PR DESCRIPTION
as proposed in #118 . Filesystem now checks if adapter has listKeys method (no need to implement it for all adapters, imho, since filesystem/ftp traversing is not subject to optimization), gridfs implements listKeys via MongoRegex.

I also added a typehint to FunctionTest $filesystem property.

@l3l0 , please check it this PR complies to your thoughts about Gaufrette. If it's ok, I'll propapbly implement it also for doctrine via LIKE (is also should be applicable to S3 / Rackspace, but I've no posibillity to test that).
