### PR TITLE
Do not compute path 2 times by each deletion.

### DIFF
--- a/src/Gaufrette/Adapter/Local.php
+++ b/src/Gaufrette/Adapter/Local.php
@@ -124,11 +124,13 @@ class Local implements Adapter,
      */
     public function delete($key)
     {
-        if ($this->isDirectory($key)) {
-            return rmdir($this->computePath($key));
+        $path = $this->computePath($key);
+
+        if (is_dir($path)) {
+            return rmdir($path);
         }
 
-        return unlink($this->computePath($key));
+        return unlink($path);
     }
 
     /**


### PR DESCRIPTION
Now every deletion occurs we fire `computePath` 2 times: one in `isDriectory` body and second in either `rmdir` and `unlink` call.

On heavy used fs it might be costly.
