### PR TITLE
AmazonS3 adapter should provide a way to retrieve the S3 object URL

### DIFF
--- a/src/Gaufrette/Adapter/AmazonS3.php
+++ b/src/Gaufrette/Adapter/AmazonS3.php
@@ -218,6 +218,27 @@ class AmazonS3 implements Adapter,
     }
 
     /**
+     * Retrieve the S3 object URL for the given key.
+     *
+     * @param string $key
+     * @param integer|string $preauth Look at \AmazonS3::get_object_url() docs
+     * @param array $opt Look at \AmazonS3::get_object_url() docs
+     *
+     * @see \AmazonS3::get_object_url()
+     *
+     * @return string The S3 object URL
+     */
+    public function getObjectUrl($key, $preauth = 0, array $opt = array())
+    {
+        return $this->service->get_object_url(
+            $this->bucket,
+            $this->computePath($key),
+            $preauth,
+            $opt
+        );
+    }
+
+    /**
      * Ensures the specified bucket exists. If the bucket does not exists
      * and the create parameter is set to true, it will try to create the
      * bucket


### PR DESCRIPTION
There needs to be a way to get S3 object URLs, this patch exposes the AmazonS3 get_object_url method.
