### PR TITLE
Better exception text

### DIFF
--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -417,7 +417,7 @@ class Ftp implements Adapter,
         // login ftp user
         if (!ftp_login($this->connection, $username, $password)) {
             $this->close();
-            throw new \RuntimeException(sprintf('Could not login as %s.', $this->username));
+            throw new \RuntimeException(sprintf('Could not login as %s.', $username));
         }
 
         // switch to passive mode if needed


### PR DESCRIPTION
After unsuccessful try to login to ftp now you get exception
with as same username as you try to log in.
