### PR TITLE
ObjectStore-method returns instance of OpenCloud\ObjectStore\Service

### DIFF
--- a/src/Gaufrette/Adapter/OpenCloud.php
+++ b/src/Gaufrette/Adapter/OpenCloud.php
@@ -5,8 +5,8 @@ namespace Gaufrette\Adapter;
 use Gaufrette\Adapter;
 use OpenCloud\ObjectStore\Container;
 use OpenCloud\ObjectStore\Service;
-use OpenCloud\ObjectStore\CreateUpdateError;
-use OpenCloud\ObjectStore\ObjFetchError;
+use OpenCloud\Base\Exceptions\CreateUpdateError;
+use OpenCloud\Base\Exceptions\ObjFetchError;
 
 /**
  * OpenCloud adapter


### PR DESCRIPTION
Following the example in the docs:

```
$connection = new OpenCloud\Rackspace(
     'https://identity.api.rackspacecloud.com/v2.0/',
     array(
         'username' => 'foo',
         'apiKey' => 'bar'
));

$objectStore = $connection->ObjectStore('cloudFiles', 'DFW', 'publicURL');

$adapter = new Gaufrette\Adapter\OpenCloud(
    $objectStore,
    'somecontainername'
);
```

...results in: "Argument 1 passed to Gaufrette\Adapter\OpenCloud::__construct() must be an instance of OpenCloud\ObjectStore, instance of OpenCloud\ObjectStore\Service given".

Reason: the connection's ObjectStore-method returns an instance of OpenCloud\ObjectStore\Service:

```
    public function ObjectStore($name=NULL, $region=NULL, $urltype=NULL) {
        return $this->Service('ObjectStore', $name, $region, $urltype);
    }
```

Let me know if you need any more information, thanks in advance!

Kind regards,
David
