### PR TITLE
RackspaceCloudFiles via OpenStack - Switched to 'ObjectStore\Service'

### DIFF
--- a/src/Gaufrette/Adapter/OpenCloud.php
+++ b/src/Gaufrette/Adapter/OpenCloud.php
@@ -102,6 +102,9 @@ class OpenCloud implements Adapter,
 
                 $object->Create($data);
             }
+            if (empty($object->bytes) && !empty($object->content_length)) {
+                return $object->content_length;
+            }
             return $object->bytes;
         }catch(CreateUpdateError $updateError){
             return false;
@@ -218,7 +221,9 @@ class OpenCloud implements Adapter,
     {
         try{
             return $this->container->DataObject($key);
-        }catch (ObjFetchError $objFetchError){
+        } catch (\OpenCloud\Base\Exceptions\ObjFetchError $ObjFetchError) {
+            return false;
+        } catch (ObjFetchError $objFetchError){
             return false;
         }
     }


### PR DESCRIPTION
I had to switch from expecting 'ObjectStore' to expecting 'ObjectStore\Service'
to get Rackspace to load with the latest code from https://github.com/rackspace/php-opencloud

This is my first implementation of Gaufrette, and perhaps I've done something wrong along the way... but I DID get this to work... but I couldn't get the 'ObjectStore' by itself, following the docs at https://github.com/rackspace/php-opencloud -- it only gave me the 'ObjectStore\Service' object.

Once I switched Gaufrette's expectations, it worked like expected.

```
    $connection = new OpenCloud\Rackspace(
        'https://identity.api.rackspacecloud.com/v2.0/',
        array(
            'username' => 'xxxxxxx',
            'apiKey' => 'xxxxxxxxxxxxx',
        )
    );
    $objectStore = $connection->ObjectStore('cloudFiles', 'ORD', 'publicURL' );
    $adapter = new Gaufrette\Adapter\OpenCloud(
        $objectStore,
        'my-container',
        true,
        true
    );
```
