### PR TITLE
OpenCloud->last_modified details, second pass

### DIFF
--- a/src/Gaufrette/Adapter/OpenCloud.php
+++ b/src/Gaufrette/Adapter/OpenCloud.php
@@ -148,7 +148,11 @@ class OpenCloud implements Adapter,
     public function mtime($key)
     {
         $this->initialize();
-        $lastModified = $this->tryGetObject($key)->last_modified;
+        $object = $this->tryGetObject($key);
+        $lastModified = $object->last_modified;
+        if (empty($lastModified) && !empty($object->extra_headers['Last-Modified'])) {
+            $lastModified = date('Y-m-d H:i:s', strtotime($object->extra_headers['Last-Modified']));
+        }
         return $lastModified;
     }
 


### PR DESCRIPTION
Implemented a secondary check to get "Last Modified" information from OpenCloud
  if not already there from the DataObject...

This relies on the API response "extra_headers"
  but it only is called if the `last_modified` property isn't already set
