### PR TITLE
Change streamMode to read-only on url_start

### DIFF
--- a/src/Gaufrette/StreamWrapper.php
+++ b/src/Gaufrette/StreamWrapper.php
@@ -194,7 +194,7 @@ class StreamWrapper
         $stream = $this->createStream($path);
 
         try {
-            $stream->open($this->createStreamMode('r+'));
+            $stream->open($this->createStreamMode('r'));
         } catch (\RuntimeException $e) {
             return false;
         }


### PR DESCRIPTION
Here's a minor fix that allows opening read-only files through Gaufrette/StreamWrapper.

Without this fix, Gaufrette opens all streams as read/write before calling stat() on them.
Afaik this is not needed, only 'r' is sufficient. Without this fix, calling 'stat' on read-only files fails.