### PR TITLE
fixed size detection

### DIFF
--- a/src/Gaufrette/Util/Size.php
+++ b/src/Gaufrette/Util/Size.php
@@ -20,6 +20,8 @@ class Size
      */
     public static function fromContent($content)
     {
-        return mb_strlen($content);
+        // Make sure to get the real length in byte and not
+        // accidentally mistake some bytes as a UTF BOM.
+        return mb_strlen($content, '8bit');
     }
 }


### PR DESCRIPTION
Without the explicit charset, PHP detects UTF BOM when there are none (like in the middle of files).
