### PR TITLE
Fixed OpenCloud faulty Exception namespacing

### DIFF
--- a/src/Gaufrette/Adapter/OpenCloud.php
+++ b/src/Gaufrette/Adapter/OpenCloud.php
@@ -5,8 +5,8 @@ namespace Gaufrette\Adapter;
 use Gaufrette\Adapter;
 use OpenCloud\ObjectStore\Container;
 use OpenCloud\ObjectStore\Service;
-use OpenCloud\Base\Exceptions\CreateUpdateError;
-use OpenCloud\Base\Exceptions\ObjFetchError;
+use OpenCloud\Common\Exceptions\CreateUpdateError;
+use OpenCloud\Common\Exceptions\ObjFetchError;
 
 /**
  * OpenCloud adapter


### PR DESCRIPTION
The newest version of the php-opencloud moved two Exceptions from namespace. I fixed them.

Without this fix writing to OpenCloud fails.
