### PR TITLE
Handle empty key in Filesystem

### DIFF
--- a/src/Gaufrette/Filesystem.php
+++ b/src/Gaufrette/Filesystem.php
@@ -259,12 +259,18 @@ class Filesystem
     }
 
     /**
-     * @param $key
-     * @throws Exception\FileNotFound
+     * Checks if matching file by given key exists in the filesystem
+     *
+     * Key must be non empty string, otherwise it will throw Exception\FileNotFound
+     * {@see http://php.net/manual/en/function.empty.php}
+     *
+     * @param string $key
+     *
+     * @throws Exception\FileNotFound   when sourceKey does not exist
      */
     private function assertHasFile($key)
     {
-        if (! $this->has($key)) {
+        if (! empty($key) && ! $this->has($key)) {
             throw new Exception\FileNotFound($key);
         }
     }


### PR DESCRIPTION
**TL;DR**

By sharing some logic for create/update actions I passed null value to the delete method in local adapter which caused:

```
Warning: rmdir(/var/www/tubylo/web/uploads): Directory not empty in /var/www/tubylo/vendor/knplabs/gaufrette/src/Gaufrette/Adapter/Local.php line 128
```

Of course I didn't want to remove whole uploads directory :)
To solve this I've added additional check in assertHasFile method

end of TL;DR

**More about the problem (optional to read)**

```
    # Gaufrette/Adapter/Local.php
    public function exists($key)
    {
        return file_exists($this->computePath($key));
    }
```

will always return true because computePath method

```
    # Gaufrette/Adapter/Local.php
    protected function computePath($key)
    {
        $this->ensureDirectoryExists($this->directory, $this->create);

        return $this->normalizePath($this->directory . '/' . $key);
    }
```

makes sure that directory exists by calling 

```
$this->ensureDirectoryExists($this->directory, $this->create);
```

This leads computePath method to return e.g. 

```
/var/www/foo/bar/web/uploads
```

which is perfectly fine for file_exists function

but not what we expected
