### PR TITLE
Update the apt database before installing libssh2

### DIFF
--- a/bin/configure_test_env.sh
+++ b/bin/configure_test_env.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+sudo apt-get update -qq
 sudo apt-get install -qq libssh2-1-dev libssh2-php
 pecl install -f mongo
 touch .interactive


### PR DESCRIPTION
this is an attempt to fix the Travis builds. It looks like their APT database is quite old so updating it before running `apt-get install` is a good idea
