### PR TITLE
Fixed Broken parsing of some errors in AzureBlobStorage adapter

### DIFF
--- a/src/Gaufrette/Adapter/AzureBlobStorage.php
+++ b/src/Gaufrette/Adapter/AzureBlobStorage.php
@@ -374,9 +374,9 @@ class AzureBlobStorage implements Adapter,
      */
     protected function getErrorCodeFromServiceException(ServiceException $exception)
     {
-        $xml = simplexml_load_string($exception->getErrorReason());
+        $xml = @simplexml_load_string($exception->getErrorReason());
 
-        if (isset($xml->Code)) {
+        if ($xml && isset($xml->Code)) {
             return (string) $xml->Code;
         }
 


### PR DESCRIPTION
Sometimes Azure Blob Storage returns HTML 4.0 messages as error message (instead that xml messages used in most of the cases) so they can't be correctly parsed with `simplexml_load_string`.

This pull request fixes the problem.
