### PR TITLE
createDirectory return false on sftp.php class

### DIFF
--- a/src/Gaufrette/Adapter/Sftp.php
+++ b/src/Gaufrette/Adapter/Sftp.php
@@ -218,6 +218,6 @@ class Sftp implements Adapter,
      */
     protected function createDirectory($directory)
     {
-        return mkdir($this->sftp->getUrl($directory), 0777, true);
+        return $this->sftp->mkdir($directory, 0777, true);
     }
 }


### PR DESCRIPTION
Each time that a new folder is created on the sftp server, mkdir function return false. Nevertheless the folder is created on the sftp server.
The lib php-ssh propose the mkdir functionnality to use directly ssh2_sftp_mkdir.
With this, the function createDirectory return the good value (true) if the folder has been created properly.
