### PR TITLE
Adds ability to set global options for the AwsS3 adapter.

### DIFF
--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -231,7 +231,13 @@ class AwsS3 implements Adapter,
         $options['Bucket'] = $this->bucket;
         $options['Key'] = $this->computePath($key);
 
-        return $options + $this->getMetadata($key);
+        /**
+         * Merge global options for adapter, which are set in the constructor, with metadata.
+         * Metadata will override global options.
+         */
+        $options = array_merge($this->options, $options, $this->getMetadata($key));
+
+        return $options;
     }
 
     private function computePath($key)


### PR DESCRIPTION
When passing in options as constructor parameters to the AwsS3 adapter, these will now be used as global options, which will be merged with metadata whenever getOptions() is called so you can do things like set a 'StorageClass' which will be applied to all keys.
