### PR TITLE
fixed leak of resource in sftp->ensureDirectoryExists()

### DIFF
--- a/src/Gaufrette/Adapter/Sftp.php
+++ b/src/Gaufrette/Adapter/Sftp.php
@@ -204,8 +204,14 @@ class Sftp implements Adapter,
     {
         $url = $this->sftp->getUrl($directory);
 
-        if (false === @opendir($url) && (!$create || !$this->createDirectory($directory))) {
+        $resource = @opendir($url);
+        if (false === $resource && (!$create || !$this->createDirectory($directory))) {
             throw new \RuntimeException(sprintf('The directory \'%s\' does not exist and could not be created.', $directory));
+        }
+        
+        // make sure we don't leak the resource
+        if (is_resource($resource)) {
+            closedir($resource);
         }
     }
 


### PR DESCRIPTION
cleanup after a successfull call to opendir(), so the OS will not get
out of resource handles on long running processes.
