### PR TITLE
FIX file size calculation for Filesystems that dont implement SizeCalculator

### DIFF
--- a/src/Gaufrette/Filesystem.php
+++ b/src/Gaufrette/Filesystem.php
@@ -249,7 +249,7 @@ class Filesystem
             return $this->adapter->size($key);
         }
 
-        return Util\Checksum::fromContent($this->read($key));
+        return Util\Size::fromContent($this->read($key));
     }
 
     /**


### PR DESCRIPTION
I consigned a copy & paste mistake in my last pull request (#237). I copied the checksum method and adjusted it for using for size calcluation. I forgot to rename `Util\Checksum` to `Util\Size`. Sorry for that!
