### PR TITLE
AwsS3 adapter: fixed rename

### DIFF
--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -102,7 +102,12 @@ class AwsS3 implements Adapter,
     public function rename($sourceKey, $targetKey)
     {
         $this->ensureBucketExists();
-        $options = $this->getOptions($targetKey, array('CopySource' => $this->computePath($sourceKey)));
+        $options = $this->getOptions(
+            $targetKey,
+            array(
+                'CopySource' => $this->bucket.'/'.$this->computePath($sourceKey),
+            )
+        );
 
         try {
             $this->service->copyObject($options);


### PR DESCRIPTION
Implementation of rename method was not in accordance to AWS documentation (and not working)...

Fixed.
