### PR TITLE
PhpseclibSftp: Creating new directories did not fully work.

### DIFF
--- a/src/Gaufrette/Adapter/PhpseclibSftp.php
+++ b/src/Gaufrette/Adapter/PhpseclibSftp.php
@@ -185,12 +185,12 @@ class PhpseclibSftp implements Adapter,
         $this->initialized = true;
     }
 
-    protected function ensureDirectoryExists($directory, $create = false)
+    protected function ensureDirectoryExists($directory, $create)
     {
         $pwd = $this->sftp->pwd();
         if ($this->sftp->chdir($directory)) {
             $this->sftp->chdir($pwd);
-        } elseif ($this->create) {
+        } elseif ($create) {
             if (!$this->sftp->mkdir($directory, 0777, true)) {
                 throw new \RuntimeException(sprintf('The directory \'%s\' does not exist and could not be created (%s).', $this->directory, $this->sftp->getLastSFTPError()));
             }


### PR DESCRIPTION
When using write() or rename() no new directories will be created, if __construct(..., ..., false) was given.

Seemed to be typo, because all calls to ensureDirectoryExists give a value for $create. Because of this, the default value was removed and replaced with the parameter.
