### PR TITLE
Allows to creates file using stream even when subdirectory does not exists

### DIFF
--- a/src/Gaufrette/Stream/Local.php
+++ b/src/Gaufrette/Stream/Local.php
@@ -31,6 +31,10 @@ class Local implements Stream
      */
     public function open(StreamMode $mode)
     {
+        $baseDirPath = dirname($this->path);
+        if ($mode->allowsWrite() && !is_dir($baseDirPath)) {
+            @mkdir($baseDirPath, 0755, true);
+        }
         try {
             $fileHandle = @fopen($this->path, $mode->getMode());
         } catch (\Exception $e) {

--- a/tests/Gaufrette/Functional/FileStream/FunctionalTestCase.php
+++ b/tests/Gaufrette/Functional/FileStream/FunctionalTestCase.php
@@ -153,6 +153,19 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function shouldHandlesSubDir()
+    {
+        file_put_contents('gaufrette://filestream/subdir/test.txt', 'test content');
+
+        $this->assertTrue(is_file('gaufrette://filestream/subdir/test.txt'));
+
+        $this->filesystem->delete('subdir/test.txt');
+        $this->assertFalse(is_file('gaufrette://filestream/subdir/test.txt'));
+    }
+
+    /**
+     * @test
+     */
     public function shouldUnlinkFile()
     {
         $this->filesystem->write('test.txt', 'some content');


### PR DESCRIPTION
Allows to creates file using stream even when subdirectory does not exists behavior to LocalStream cause InMemoryBuffer working like this before.
