### PR TITLE
Set getPaths function public

### DIFF
--- a/src/Gaufrette/Adapter/MogileFS.php
+++ b/src/Gaufrette/Adapter/MogileFS.php
@@ -304,7 +304,7 @@ class MogileFS implements Adapter
      * @param key File key
      * @return mixed Array on success, false on failure
      */
-    private function getPaths($key)
+    public function getPaths($key)
     {
         $res = $this->doRequest("GET_PATHS", array("key" => $key));
         unset($res['paths']);


### PR DESCRIPTION
Updated the getPaths function to public so that file paths can be returned from mogileFS.