### PR TITLE
Fixed the return value of fetchKeys in case of errors

### DIFF
--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -359,7 +359,7 @@ class Ftp implements Adapter,
         $lines = ftp_rawlist($this->getConnection(), '-alR '. $this->directory . $directory);
 
         if (false === $lines) {
-            return array();
+            return array('keys' => array(), 'dirs' => array());
         }
 
         $regexDir = '/'.preg_quote($this->directory . $directory, '/').'\/?(.+):$/u';


### PR DESCRIPTION
`listKeys` expects to always receive an array with `keys` and `dirs` in it. Otherwise, it throws a notice
