### PR TITLE
Fixed the error handling for invalid ftp login

### DIFF
--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -511,7 +511,7 @@ class Ftp implements Adapter,
         $password = $this->password ? : '';
 
         // login ftp user
-        if (!ftp_login($this->connection, $username, $password)) {
+        if (!@ftp_login($this->connection, $username, $password)) {
             $this->close();
             throw new \RuntimeException(sprintf('Could not login as %s.', $username));
         }


### PR DESCRIPTION
The ftp_login function throws a PHP warning on failure as well as returning false
