### PR TITLE
Provide mime type through the local adapter

### DIFF
--- a/spec/Gaufrette/Adapter/LocalSpec.php
+++ b/spec/Gaufrette/Adapter/LocalSpec.php
@@ -24,6 +24,16 @@ class LocalSpec extends ObjectBehavior
         $this->shouldHaveType('Gaufrette\Adapter\ChecksumCalculator');
     }
 
+    function it_is_a_mime_type_provider()
+    {
+        $this->shouldHaveType('Gaufrette\Adapter\MimeTypeProvider');
+    }
+
+    function it_gets_the_file_mime_type()
+    {
+        $this->mimeType('filename')->shouldReturn('text/plain');
+    }
+
     function it_is_stream_factory()
     {
         $this->shouldHaveType('Gaufrette\Adapter\StreamFactory');
@@ -135,6 +145,10 @@ class LocalSpec extends ObjectBehavior
         $this
             ->shouldThrow(new \RuntimeException(sprintf('The directory "%s" does not exist.', vfsStream::url('other'))))
             ->duringChecksum('filename')
+        ;
+        $this
+            ->shouldThrow(new \RuntimeException(sprintf('The directory "%s" does not exist.', vfsStream::url('other'))))
+            ->duringMimeType('filename')
         ;
     }
 

--- a/spec/Gaufrette/FilesystemSpec.php
+++ b/spec/Gaufrette/FilesystemSpec.php
@@ -400,11 +400,32 @@ class FilesystemSpec extends ObjectBehavior
 
         $this->checksum('filename')->shouldReturn(12);
     }
+
+    /**
+     * @param \spec\Gaufrette\Adapter $extendedAdapter
+     */
+    function it_delegates_mime_type_resolution_to_adapter_when_adapter_is_mime_type_provider($extendedAdapter)
+    {
+        $this->beConstructedWith($extendedAdapter);
+        $extendedAdapter->exists('filename')->willReturn(true);
+        $extendedAdapter->mimeType('filename')->willReturn('text/plain');
+
+        $this->mimeType('filename')->shouldReturn('text/plain');
+    }
+
+    function it_cannot_resolve_mime_type_if_the_adapter_cannot_provide_it($adapter)
+    {
+        $adapter->exists('filename')->willReturn(true);
+        $this
+            ->shouldThrow(new \LogicException(sprintf('Adapter "%s" cannot provide MIME type', get_class($adapter->getWrappedObject()))))
+            ->duringMimeType('filename');
+    }
 }
 
 interface Adapter extends \Gaufrette\Adapter,
                           \Gaufrette\Adapter\FileFactory,
                           \Gaufrette\Adapter\StreamFactory,
                           \Gaufrette\Adapter\ChecksumCalculator,
-                          \Gaufrette\Adapter\MetadataSupporter
+                          \Gaufrette\Adapter\MetadataSupporter,
+                          \Gaufrette\Adapter\MimeTypeProvider
 {}

--- a/src/Gaufrette/Adapter/Local.php
+++ b/src/Gaufrette/Adapter/Local.php
@@ -17,7 +17,8 @@ use Gaufrette\Exception;
 class Local implements Adapter,
                        StreamFactory,
                        ChecksumCalculator,
-                       SizeCalculator
+                       SizeCalculator,
+                       MimeTypeProvider
 {
     protected $directory;
     private $create;
@@ -151,14 +152,30 @@ class Local implements Adapter,
         return new Stream\Local($this->computePath($key));
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function checksum($key)
     {
         return Util\Checksum::fromFile($this->computePath($key));
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function size($key)
     {
         return Util\Size::fromFile($this->computePath($key));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mimeType($key)
+    {
+        $fileInfo = new \finfo(FILEINFO_MIME_TYPE);
+
+        return $fileInfo->file($this->computePath($key));
     }
 
     /**

--- a/src/Gaufrette/Adapter/MimeTypeProvider.php
+++ b/src/Gaufrette/Adapter/MimeTypeProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Gaufrette\Adapter;
+
+/**
+ * Interface which add mime type provider support to adapter
+ *
+ * @author Gildas Quemener <gildas.quemener@gmail.com>
+ */
+interface MimeTypeProvider
+{
+    /**
+     * Returns the mime type of the specified key
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    public function mimeType($key);
+}

--- a/src/Gaufrette/Filesystem.php
+++ b/src/Gaufrette/Filesystem.php
@@ -277,6 +277,27 @@ class Filesystem
     }
 
     /**
+     * Get the mime type of the provided key
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    public function mimeType($key)
+    {
+        $this->assertHasFile($key);
+
+        if ($this->adapter instanceof Adapter\MimeTypeProvider) {
+            return $this->adapter->mimeType($key);
+        }
+
+        throw new \LogicException(sprintf(
+            'Adapter "%s" cannot provide MIME type',
+            get_class($this->adapter)
+        ));
+    }
+
+    /**
      * Checks if matching file by given key exists in the filesystem
      *
      * Key must be non empty string, otherwise it will throw Exception\FileNotFound


### PR DESCRIPTION
This patch brings mime type awareness to the local adapter as discussed here: https://github.com/KnpLabs/Gaufrette/issues/178 a few months ago.
It allows to smoothly integrate this feature among all the adapters.
