### PR TITLE
Cache::exists() performance fix

### DIFF
--- a/src/Gaufrette/Adapter/Cache.php
+++ b/src/Gaufrette/Adapter/Cache.php
@@ -115,7 +115,11 @@ class Cache implements Adapter,
      */
     public function exists($key)
     {
-        return $this->source->exists($key);
+        if ($this->needsReload($key)) {
+            return $this->source->exists($key);
+        } else {
+            return $this->cache->exists($key);
+        }
     }
 
     /**

--- a/src/Gaufrette/Adapter/Cache.php
+++ b/src/Gaufrette/Adapter/Cache.php
@@ -117,9 +117,8 @@ class Cache implements Adapter,
     {
         if ($this->needsReload($key)) {
             return $this->source->exists($key);
-        } else {
-            return $this->cache->exists($key);
         }
+        return $this->cache->exists($key);
     }
 
     /**


### PR DESCRIPTION
Hello! Thanks for a great library.
I tried to use a caching feature - the source adapter was AWS S3 and the cache adapter was Local. Calling read('...') for the second time was faster, but still was taking about 0.5 seconds, which is not normal for reading local file. I find out this happens because of calling exist on source adapter from FileSystem::assertHasFile(). Then I found out that Cache::exists() just calls source adapter, I fixed it and ended up with expected reading time (about 0.01). Maybe I missed something and it can cause some problems (wrong exists() result under certain circumstances, for example), but I don't think so. 