### PR TITLE
Fixed AmazonS3 keys method

### DIFF
--- a/spec/Gaufrette/Adapter/AmazonS3Spec.php
+++ b/spec/Gaufrette/Adapter/AmazonS3Spec.php
@@ -461,7 +461,7 @@ class AmazonS3Spec extends ObjectBehavior
         $service
             ->get_object_list('bucketName')
             ->shouldBeCalled()
-            ->willReturn(array('filename2', 'aaa/filename', 'filename1'))
+            ->willReturn(array('filename2', 'aaa/', 'aaa/filename', 'filename1'))
         ;
 
         $this->keys()->shouldReturn(array('aaa', 'aaa/filename', 'filename1', 'filename2'));

--- a/src/Gaufrette/Adapter/AmazonS3.php
+++ b/src/Gaufrette/Adapter/AmazonS3.php
@@ -197,14 +197,28 @@ class AmazonS3 implements Adapter,
     {
         $this->ensureBucketExists();
 
-        $list = $this->service->get_object_list($this->bucket);
+        $rootdir = $this->getDirectory().'/';
+        if ($rootdir !== '/') {
+            $list = $this->service->get_object_list($this->bucket, array('prefix' => $this->getDirectory()));
+        } else {
+            $list = $this->service->get_object_list($this->bucket);
+        }
 
         $keys = array();
-        foreach ($list as $file) {
-            if ('.' !== dirname($file)) {
-                $keys[] = dirname($file);
+        foreach ($list as $fullpath) {
+            if ($fullpath === $rootdir) {
+                continue;
+            } elseif ($rootdir !== '/') {
+                $file = substr($fullpath, strlen($rootdir));
+            } else {
+                $file = $fullpath;
             }
-            $keys[] = $file;
+
+            if (strrpos($file, '/') === strlen($file) - 1) {
+                $keys[] = substr($file, 0, -1);
+            } else {
+                $keys[] = $file;
+            }
         }
         sort($keys);
 


### PR DESCRIPTION
The method didn't care about "directory" option.

I also modified phpspecs to reflect real "get_object_list" behaviour : an item in a subdir isn't listed alone, the subdir is listed before.

Travis build is OK

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/knplabs/gaufrette/307)
<!-- Reviewable:end -->
