### PR TITLE
Added possibility to throw specific exceptions at the adapter level

### DIFF
--- a/spec/Gaufrette/FilesystemSpec.php
+++ b/spec/Gaufrette/FilesystemSpec.php
@@ -181,10 +181,10 @@ class FilesystemSpec extends ObjectBehavior
     function it_fails_when_write_is_not_successful($adapter)
     {
         $adapter->exists('filename')->willReturn(false);
-        $adapter->write('filename', 'some content to write')->shouldBeCalled()->willReturn(false);
+        $adapter->write('filename', 'some content to write')->shouldBeCalled()->willThrow(new \RuntimeException());
 
         $this
-            ->shouldThrow(new \RuntimeException('Could not write the "filename" key content.'))
+            ->shouldThrow(new \RuntimeException())
             ->duringWrite('filename', 'some content to write')
         ;
     }

--- a/src/Gaufrette/Adapter.php
+++ b/src/Gaufrette/Adapter.php
@@ -24,6 +24,7 @@ interface Adapter
      *
      * @param string $key
      * @param string $content
+     * @throws \RuntimeException
      *
      * @return integer|boolean The number of bytes that were written into the file
      */

--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -140,7 +140,7 @@ class AwsS3 implements Adapter,
             $this->service->putObject($options);
             return strlen($content);
         } catch (\Exception $e) {
-            return false;
+            throw new \RuntimeException('Could not put object on S3.', 0, $e);
         }
     }
 

--- a/src/Gaufrette/Filesystem.php
+++ b/src/Gaufrette/Filesystem.php
@@ -121,10 +121,6 @@ class Filesystem
 
         $numBytes = $this->adapter->write($key, $content);
 
-        if (false === $numBytes) {
-            throw new \RuntimeException(sprintf('Could not write the "%s" key content.', $key));
-        }
-
         return $numBytes;
     }
 


### PR DESCRIPTION
This aims to solve #224, by adding the possibility of throwing a specific `\RuntimeException` from the adapter level. This can be a simple wrapped exception, like implemented on the AwsS3 adapter:

```php
try {
    $this->service->putObject($options);
    return strlen($content);
} catch (\Exception $e) {
    throw new \RuntimeException('Could not put object on S3.', 0, $e);
}
```

Or a full subtype exception of the `\RuntimeException`.

If this PR makes sense to you, I'll change all of the other adapters.