### PR TITLE
Fix rename in AwsS3 adapter

### DIFF
--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -111,7 +111,7 @@ class AwsS3 implements Adapter,
 
         try {
             $this->service->copyObject($options);
-            return true;
+            return $this->delete($sourceKey);
         } catch (\Exception $e) {
             return false;
         }

--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -110,7 +110,7 @@ class AwsS3 implements Adapter,
         );
 
         try {
-            $this->service->copyObject($options);
+            $this->service->copyObject(array_merge($options, $this->getMetadata($targetKey)));
             return $this->delete($sourceKey);
         } catch (\Exception $e) {
             return false;


### PR DESCRIPTION
- The source file was left on S3. Added deletion after the copy operation.
- Added metadata handling for destination key. By default, S3 sets the destination ACL to private during copy operation, so this allows user to easily make the renamed file public.