### PR TITLE
Invalidate instead of update fileRegister

### DIFF
--- a/src/Gaufrette/Filesystem.php
+++ b/src/Gaufrette/Filesystem.php
@@ -77,7 +77,6 @@ class Filesystem
         }
         
         if($this->isFileInRegister($sourceKey)) {
-            $this->fileRegister[$targetKey] = $this->fileRegister[$sourceKey];
             unset($this->fileRegister[$sourceKey]);
         }
 


### PR DESCRIPTION
After renaming a file, the file in the fileRegister contains the wrong
key. Therefore invalidate the cache instead of updating it.

See #197

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/knplabs/gaufrette/316)
<!-- Reviewable:end -->
