### PR TITLE
Allow Local adapter mkdir mode to cascade to its Stream

### DIFF
--- a/src/Gaufrette/Adapter/Local.php
+++ b/src/Gaufrette/Adapter/Local.php
@@ -149,7 +149,7 @@ class Local implements Adapter,
      */
     public function createStream($key)
     {
-        return new Stream\Local($this->computePath($key));
+        return new Stream\Local($this->computePath($key), $this->mode);
     }
 
     /**

--- a/src/Gaufrette/Stream/Local.php
+++ b/src/Gaufrette/Stream/Local.php
@@ -15,15 +15,18 @@ class Local implements Stream
     private $path;
     private $mode;
     private $fileHandle;
+    private $mkdirMode;
 
     /**
      * Constructor
      *
      * @param string $path
+     * @param int    $mkdirMode
      */
-    public function __construct($path)
+    public function __construct($path, $mkdirMode = 0755)
     {
         $this->path = $path;
+        $this->mkdirMode = $mkdirMode;
     }
 
     /**
@@ -33,7 +36,7 @@ class Local implements Stream
     {
         $baseDirPath = dirname($this->path);
         if ($mode->allowsWrite() && !is_dir($baseDirPath)) {
-            @mkdir($baseDirPath, 0755, true);
+            @mkdir($baseDirPath, $this->mkdirMode, true);
         }
         try {
             $fileHandle = @fopen($this->path, $mode->getMode());


### PR DESCRIPTION
I'm setting the mode for ensuring directories get created properly in the `Local` adapter as `0777`, but it's not respected by the Stream implementation of the Local adapter.  This causes my apache user and the cli user not to be able to read/write the same set of files when using streams.

**Note:**  This is a small BC break because the mode that comes from the `Local` adapter is defaulted to `0777` and the mkdir command hardcoded in the `Stream\Local` is `0755`.  Let me know if this is a problem or it's acceptable as is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/knplabs/gaufrette/320)
<!-- Reviewable:end -->
