### PR TITLE
Fixed an undefined index.

### DIFF
--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -436,7 +436,7 @@ class Ftp implements Adapter,
                         'name'  => $infos[8]
                     );
                 }
-            } else {
+            } elseif (count($infos) >= 4) {
                 $isDir = (boolean) ('<dir>' === $infos[2]);
                 $parsed[] = array(
                     'perms' => $isDir ? 'd' : '-',


### PR DESCRIPTION
The FTP raw directory listing begins with a "total" line, which is causing an undefined index in the FTP adapter.