### PR TITLE
Limit crawler files scope

### DIFF
--- a/src/Gaufrette/Adapter/Local.php
+++ b/src/Gaufrette/Adapter/Local.php
@@ -88,10 +88,15 @@ class Local implements Adapter,
     /**
      * {@inheritDoc}
      */
-    public function keys()
+    public function keys($prefix = null)
     {
-        $this->ensureDirectoryExists($this->directory, $this->create);
-
+        if($prefix){
+            $this->directory = $this->computePath(Util\Path::normalize($prefix));
+            $this->ensureDirectoryExists($this->directory, true);
+        }else{                   
+            $this->ensureDirectoryExists($this->directory, $this->create);
+        }
+        
         try {
             $files = new \RecursiveIteratorIterator(
                 new \RecursiveDirectoryIterator(

--- a/src/Gaufrette/Filesystem.php
+++ b/src/Gaufrette/Filesystem.php
@@ -177,9 +177,9 @@ class Filesystem
      *
      * @return array
      */
-    public function keys()
+    public function keys($prefix = null)
     {
-        return $this->adapter->keys();
+        return $this->adapter->keys($prefix);
     }
 
     /**
@@ -201,8 +201,8 @@ class Filesystem
         $dirs = array();
         $keys = array();
 
-        foreach ($this->keys() as $key) {
-            if (empty($prefix) || 0 === strpos($key, $prefix)) {
+        foreach ($this->keys($prefix) as $key) {
+            if (empty($prefix)) {
                 if ($this->adapter->isDirectory($key)) {
                     $dirs[] = $key;
                 } else {


### PR DESCRIPTION
In case in Local.php-keys() have to get list on very big project, it's very long ! The better way is specify the scope before crawl.
My edits give to Filesystem this possibility.