### PR TITLE
make rename with AWS S3 adapter delete source file

### DIFF
--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -111,10 +111,11 @@ class AwsS3 implements Adapter,
 
         try {
             $this->service->copyObject($options);
-            return true;
         } catch (\Exception $e) {
             return false;
         }
+
+        return $this->delete($sourceKey);
     }
 
     /**


### PR DESCRIPTION
A rename operation should remove the source file.

This already happens in the AWS S3 adapter for Flysystem: https://github.com/thephpleague/flysystem-aws-s3-v2/blob/master/src/AwsS3Adapter.php#L254