### PR TITLE
Fix infinite loop bug check directory with Slash and backslash

### DIFF
--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -338,7 +338,7 @@ class Ftp implements Adapter,
      */
     private function isDir($directory)
     {
-        if ('/' === $directory) {
+        if ('/' === $directory || '\\' === $directory) {
             return true;
         }
 


### PR DESCRIPTION
Check directory is valid with Slash and backslash, not only with slash.
php function dirname() used in this class can return backslash