### PR TITLE
Use getPartialObject for exists check.

### DIFF
--- a/spec/Gaufrette/Adapter/LazyOpenCloudSpec.php
+++ b/spec/Gaufrette/Adapter/LazyOpenCloudSpec.php
@@ -37,6 +37,6 @@ class LazyOpenCloudSpec extends ObjectBehavior
         $objectStore->getContainer("test-container-name")->shouldBeCalled()->willReturn($container);
         $container->getObject("test-file-name")->willThrow(new ObjectNotFoundException());
 
-        $this->exists("test-file-name");
+        $this->read("test-file-name");
     }
 }

--- a/spec/Gaufrette/Adapter/OpenCloudSpec.php
+++ b/spec/Gaufrette/Adapter/OpenCloudSpec.php
@@ -87,7 +87,7 @@ class OpenCloudSpec extends ObjectBehavior
      */
     function it_returns_true_if_key_exists($container, $object)
     {
-        $container->getObject('test')->willReturn($object);
+        $container->getPartialObject('test')->willReturn($object);
 
         $this->exists('test')->shouldReturn(true);
     }
@@ -97,7 +97,7 @@ class OpenCloudSpec extends ObjectBehavior
      */
     function it_returns_false_if_key_does_not_exist($container)
     {
-        $container->getObject('test')->willThrow(new ObjectNotFoundException());
+        $container->getPartialObject('test')->willThrow(new BadResponseException());
 
         $this->exists('test')->shouldReturn(false);
     }
@@ -215,7 +215,7 @@ class OpenCloudSpec extends ObjectBehavior
 
         $objectStore->getContainer($containerName)->willThrow(new BadResponseException());
         $objectStore->createContainer($containerName)->willReturn($container);
-        $container->getObject($filename)->willThrow(new ObjectNotFoundException());
+        $container->getPartialObject($filename)->willThrow(new BadResponseException());
 
         $this->beConstructedWith($objectStore, $containerName, true);
 

--- a/src/Gaufrette/Adapter/OpenCloud.php
+++ b/src/Gaufrette/Adapter/OpenCloud.php
@@ -126,7 +126,13 @@ class OpenCloud implements Adapter,
      */
     public function exists($key)
     {
-        return $this->tryGetObject($key) !== false;
+        try {
+            $exists = $this->getContainer()->getPartialObject($key) !== false;
+        } catch (BadResponseException $objFetchError) {
+            return false;
+        }
+
+        return $exists;
     }
 
     /**


### PR DESCRIPTION
Means we simply get the head of the object to check it exists rather
than read the entire object which can take a long time if particularly
large file.

Ideally would have liked to have used the [objectExists](https://github.com/rackspace/php-opencloud/blob/working/lib/OpenCloud/ObjectStore/Resource/Container.php#L404) check but that's on a a newer version that Gaufrette currently doesn't support. If we upgrade the version of OpenCloud we should look to use that rather than getPartialObject but they both achieve the same outcome.