### PR TITLE
List keys without options['directory'] on AwsS3 adapter

### DIFF
--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -291,6 +291,6 @@ class AwsS3 implements Adapter,
      */
     protected function computeKey($path)
     {
-        return ltrim(substr($path, strlen($this->options['directory']), '/'));
+        return ltrim(substr($path, strlen($this->options['directory'])), '/');
     }
 }

--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -188,7 +188,7 @@ class AwsS3 implements Adapter,
         $keys = array();
         $iter = $this->service->getIterator('ListObjects', $options);
         foreach ($iter as $file) {
-            $keys[] = $file['Key'];
+            $keys[] = $this->computeKey($file['Key']);
         }
 
         return $keys;
@@ -280,5 +280,17 @@ class AwsS3 implements Adapter,
         }
 
         return sprintf('%s/%s', $this->options['directory'], $key);
+    }
+
+    /**
+     * Computes the key from the specified path
+     *
+     * @param string $path
+     *
+     * return string
+     */
+    protected function computeKey($path)
+    {
+        return ltrim(substr($path, strlen($this->options['directory']), '/');
     }
 }

--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -291,6 +291,6 @@ class AwsS3 implements Adapter,
      */
     protected function computeKey($path)
     {
-        return ltrim(substr($path, strlen($this->options['directory']), '/');
+        return ltrim(substr($path, strlen($this->options['directory']), '/'));
     }
 }

--- a/tests/Gaufrette/Functional/Adapter/AwsS3Test.php
+++ b/tests/Gaufrette/Functional/Adapter/AwsS3Test.php
@@ -106,17 +106,12 @@ class AwsS3Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals('https://bucket.s3.amazonaws.com/bar/foo', $adapter->getUrl('foo'));
     }
 
-    /**
-     * @test
-     * @covers Gaufrette\Adapter\AwsS3
-     */
     public function shouldListKeysWithoutDirectory()
     {
         $client = $this->getClient();
         $adapter = new AwsS3($client, 'bucket', array('directory' => 'bar'));
         $adapter->write('test.txt', 'some content');
         $keys = $adapter->listKeys();
-
         $this->assertEquals('test.txt', $keys['key']);
     }
 }

--- a/tests/Gaufrette/Functional/Adapter/AwsS3Test.php
+++ b/tests/Gaufrette/Functional/Adapter/AwsS3Test.php
@@ -105,4 +105,18 @@ class AwsS3Test extends \PHPUnit_Framework_TestCase
         $adapter = new AwsS3($client, 'bucket', array('directory' => 'bar'));
         $this->assertEquals('https://bucket.s3.amazonaws.com/bar/foo', $adapter->getUrl('foo'));
     }
+
+    /**
+     * @test
+     * @covers Gaufrette\Adapter\AwsS3
+     */
+    public function shouldListKeysWithoutDirectory()
+    {
+        $client = $this->getClient();
+        $adapter = new AwsS3($client, 'bucket', array('directory' => 'bar'));
+        $adapter->write('test.txt', 'some content');
+        $keys = $adapter->listKeys();
+
+        $this->assertEquals('test.txt', $keys['key']);
+    }
 }


### PR DESCRIPTION
This is a suggestion to correct this issue:

https://github.com/KnpLabs/Gaufrette/issues/223

The AwsS3 adapter was returning a list of keys with the options['directory'] in the path. This is not the behavior of other adapters (e.g: Local). And can be annoying if we try, for example, to duplicate a key on the bucket just by listing the keys and then writing them. The result will be a directory with the same name inside the main directory. 