### PR TITLE
makes AwsS3 adapter implement the SizeCalculator interface

### DIFF
--- a/spec/Gaufrette/Adapter/AwsS3Spec.php
+++ b/spec/Gaufrette/Adapter/AwsS3Spec.php
@@ -29,4 +29,9 @@ class AwsS3Spec extends ObjectBehavior
     {
         $this->shouldHaveType('Gaufrette\Adapter\MetadataSupporter');
     }
+
+    function it_supports_sizecalculator()
+    {
+        $this->shouldHaveType('Gaufrette\Adapter\SizeCalculator');
+    }
 }

--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -13,7 +13,8 @@ use Aws\S3\S3Client;
  */
 class AwsS3 implements Adapter,
                        MetadataSupporter,
-                       ListKeysAware
+                       ListKeysAware,
+                       SizeCalculator
 {
     protected $service;
     protected $bucket;
@@ -160,6 +161,19 @@ class AwsS3 implements Adapter,
         try {
             $result = $this->service->headObject($this->getOptions($key));
             return strtotime($result['LastModified']);
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function size($key)
+    {
+        try {
+            $result = $this->service->headObject($this->getOptions($key));
+            return $result['ContentLength'];
         } catch (\Exception $e) {
             return false;
         }


### PR DESCRIPTION
This PR updates the AwsS3 adapter to implement the SizeCalculator interface to prevent downloading the whole file just for getting the size information. I needed this to set the correct content length header while streaming a S3 object via various Goufrette adapters (dev = local, prod = s3).

PS: This is my very first PR ever! So please be patient with me. :)