### PR TITLE
Fix duplicates file content when read file using MogileFS adapter

### DIFF
--- a/src/Gaufrette/Adapter/MogileFS.php
+++ b/src/Gaufrette/Adapter/MogileFS.php
@@ -52,6 +52,7 @@ class MogileFS implements Adapter
         $data = '';
 
         if ($paths) {
+            shuffle($paths);
             foreach ($paths as $path) {
                 $fh = fopen($path, 'r');
 
@@ -64,6 +65,7 @@ class MogileFS implements Adapter
                 }
 
                 fclose($fh);
+                break;
             }
         }
 


### PR DESCRIPTION
This PR fixes duplicate file content when read file using MogileFS adapter.
GET_PATHS returns all urls to the same file for each tracker we configured as a replication.