### PR TITLE
ObjectStoreFactory currently force 'cloudFiles' as Object Store type value

### DIFF
--- a/src/Gaufrette/Adapter/OpenStackCloudFiles/ObjectStoreFactory.php
+++ b/src/Gaufrette/Adapter/OpenStackCloudFiles/ObjectStoreFactory.php
@@ -27,14 +27,21 @@ class ObjectStoreFactory implements ObjectStoreFactoryInterface
     protected $urlType;
 
     /**
+     * @var string
+     */
+    protected $objectStoreType;
+
+    /**
      * Constructor
      *
      * @param OpenStack $connection
      * @param string $region
      * @param string $urlType
+     & @param string $objectStoreType
      */
-    public function __construct(OpenStack $connection, $region, $urlType)
+    public function __construct(OpenStack $connection, $region, $urlType, $objectStoreType = 'cloudFiles')
     {
+	$this->objectStoreType = $objectStoreType;
         $this->connection = $connection;
         $this->region = $region;
         $this->urlType = $urlType;
@@ -45,6 +52,6 @@ class ObjectStoreFactory implements ObjectStoreFactoryInterface
      */
     public function getObjectStore()
     {
-        return $this->connection->objectStoreService('cloudFiles', $this->region, $this->urlType);
+        return $this->connection->objectStoreService($this->objectStoreType, $this->region, $this->urlType);
     }
 }

--- a/src/Gaufrette/Adapter/OpenStackCloudFiles/ObjectStoreFactory.php
+++ b/src/Gaufrette/Adapter/OpenStackCloudFiles/ObjectStoreFactory.php
@@ -37,7 +37,7 @@ class ObjectStoreFactory implements ObjectStoreFactoryInterface
      * @param OpenStack $connection
      * @param string $region
      * @param string $urlType
-     & @param string $objectStoreType
+     * @param string $objectStoreType
      */
     public function __construct(OpenStack $connection, $region, $urlType, $objectStoreType = 'cloudFiles')
     {

--- a/src/Gaufrette/Adapter/OpenStackCloudFiles/ObjectStoreFactory.php
+++ b/src/Gaufrette/Adapter/OpenStackCloudFiles/ObjectStoreFactory.php
@@ -41,7 +41,7 @@ class ObjectStoreFactory implements ObjectStoreFactoryInterface
      */
     public function __construct(OpenStack $connection, $region, $urlType, $objectStoreType = 'cloudFiles')
     {
-	$this->objectStoreType = $objectStoreType;
+        $this->objectStoreType = $objectStoreType;
         $this->connection = $connection;
         $this->region = $region;
         $this->urlType = $urlType;


### PR DESCRIPTION
I need to use 'swift' as object store type and this change allow me to do it.