### PR TITLE
ObjectStoreFactory currently force 'cloudFiles' as Object Store type value

### DIFF
--- a/src/Gaufrette/Adapter/OpenStackCloudFiles/ObjectStoreFactory.php
+++ b/src/Gaufrette/Adapter/OpenStackCloudFiles/ObjectStoreFactory.php
@@ -27,17 +27,24 @@ class ObjectStoreFactory implements ObjectStoreFactoryInterface
     protected $urlType;
 
     /**
+     * @var string
+     */
+    protected $objectStoreType;
+
+    /**
      * Constructor
      *
      * @param OpenStack $connection
      * @param string $region
      * @param string $urlType
+     * @param string $objectStoreType
      */
-    public function __construct(OpenStack $connection, $region, $urlType)
+    public function __construct(OpenStack $connection, $region, $urlType, $objectStoreType = 'cloudFiles')
     {
         $this->connection = $connection;
         $this->region = $region;
         $this->urlType = $urlType;
+        $this->objectStoreType = $objectStoreType;
     }
 
     /**
@@ -45,6 +52,6 @@ class ObjectStoreFactory implements ObjectStoreFactoryInterface
      */
     public function getObjectStore()
     {
-        return $this->connection->objectStoreService('cloudFiles', $this->region, $this->urlType);
+        return $this->connection->objectStoreService($this->objectStoreType, $this->region, $this->urlType);
     }
 }


### PR DESCRIPTION
-- Same PR as my previous [#360](https://github.com/KnpLabs/Gaufrette/pull/360) but now cleaned. @NiR- Sorry for the inconvenience

I needed to use 'swift' as object store type for [OVH PCS](https://www.ovh.com/us/cloud/storage/). This change allow to specify a value in the constructor

Full configuration example :

config.yml
```yaml
knp_gaufrette:
    adapters:
        ovh:
           lazy_opencloud:
                connection_factory_id: opencloud.connection_factory
                container_name: %openstack_container%
    filesystems:
        ovh:
            adapter:    ovh
            alias:      ovh_filesystem
    stream_wrapper: ~
```

services.yml
```yaml
services:
    opencloud.connection:
        class: OpenCloud\OpenStack
        arguments:
          - %openstack_identity_url%
          - {username: %openstack_username%, password: %openstack_password%, tenantName: %openstack_tenant_name%}

    opencloud.connection_factory:
        class: Gaufrette\Adapter\OpenStackCloudFiles\ObjectStoreFactory
        arguments:
          - "@opencloud.connection"
          - 'SBG1' # Object storage region
          - 'publicURL' # url type
          - 'swift' # Object storage type
```