### PR TITLE
Improve directory handling in StreamWrapper

### DIFF
--- a/spec/Gaufrette/StreamWrapperSpec.php
+++ b/spec/Gaufrette/StreamWrapperSpec.php
@@ -248,10 +248,12 @@ class StreamWrapperSpec extends ObjectBehavior
     /**
      * @param \Gaufrette\Stream $stream
      */
-    function it_does_not_stat_when_cannot_open($stream)
+    function it_stats_even_if_it_cannot_be_open($filesystem, $stream)
     {
+        $filesystem->createStream('dir/')->willReturn($stream);
         $stream->open(Argument::any())->willThrow(new \RuntimeException);
-        $this->url_stat('gaufrette://some/filename', STREAM_URL_STAT_LINK)->shouldReturn(false);
+        $stream->stat(Argument::any())->willReturn(array('mode' => 16893));
+        $this->url_stat('gaufrette://some/dir/', STREAM_URL_STAT_LINK)->shouldReturn(array('mode' => 16893));
     }
 
     /**

--- a/src/Gaufrette/Adapter/StreamFactory.php
+++ b/src/Gaufrette/Adapter/StreamFactory.php
@@ -14,7 +14,7 @@ interface StreamFactory
      *
      * @param string $key
      *
-     * @return Gaufrette\Stream
+     * @return \Gaufrette\Stream
      */
     public function createStream($key);
 }

--- a/src/Gaufrette/Filesystem.php
+++ b/src/Gaufrette/Filesystem.php
@@ -362,4 +362,14 @@ class Filesystem
             unset($this->fileRegister[$key]);
         }
     }
+
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function isDirectory($key)
+    {
+        return $this->adapter->isDirectory($key);
+    }
 }

--- a/src/Gaufrette/Stream/InMemoryBuffer.php
+++ b/src/Gaufrette/Stream/InMemoryBuffer.php
@@ -158,17 +158,18 @@ class InMemoryBuffer implements Stream
     public function stat()
     {
         if ($this->filesystem->has($this->key)) {
-            $time = $this->filesystem->mtime($this->key);
+            $isDirectory = $this->filesystem->isDirectory($this->key);
+            $time        = $this->filesystem->mtime($this->key);
 
             $stats = array(
                 'dev'   => 1,
                 'ino'   => 0,
-                'mode'  => 33204,
+                'mode'  => $isDirectory ? 16893 : 33204,
                 'nlink' => 1,
                 'uid'   => 0,
                 'gid'   => 0,
                 'rdev'  => 0,
-                'size'  => Util\Size::fromContent($this->content),
+                'size'  => $isDirectory ? 0 : Util\Size::fromContent($this->content),
                 'atime' => $time,
                 'mtime' => $time,
                 'ctime' => $time,

--- a/src/Gaufrette/Stream/Local.php
+++ b/src/Gaufrette/Stream/Local.php
@@ -157,6 +157,8 @@ class Local implements Stream
     {
         if ($this->fileHandle) {
             return fstat($this->fileHandle);
+        } elseif (!is_resource($this->fileHandle) && is_dir($this->path)) {
+            return stat($this->path);
         }
 
         return false;

--- a/src/Gaufrette/StreamWrapper.php
+++ b/src/Gaufrette/StreamWrapper.php
@@ -77,6 +77,8 @@ class StreamWrapper
     /**
      * @param string $scheme    - protocol scheme
      * @param string $className
+     *
+     * @return bool
      */
     protected static function streamWrapperRegister($scheme, $className)
     {
@@ -198,7 +200,6 @@ class StreamWrapper
         try {
             $stream->open($this->createStreamMode('r+'));
         } catch (\RuntimeException $e) {
-            return false;
         }
 
         return $stream->stat();

--- a/tests/Gaufrette/Functional/FileStream/LocalTest.php
+++ b/tests/Gaufrette/Functional/FileStream/LocalTest.php
@@ -12,8 +12,7 @@ class LocalTest extends FunctionalTestCase
     public function setUp()
     {
         $this->directory = __DIR__.DIRECTORY_SEPARATOR.'filesystem';
-        @mkdir($this->directory);
-        @chmod($this->directory, 0777);
+        @mkdir($this->directory.DIRECTORY_SEPARATOR.'subdir', 0777, true);
         $this->filesystem = new Filesystem(new LocalAdapter($this->directory, true));
 
         $this->registerLocalFilesystemInStream();
@@ -27,5 +26,14 @@ class LocalTest extends FunctionalTestCase
         if (is_dir($this->directory)) {
             @rmdir($this->directory);
         }
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSupportsDirectory()
+    {
+        $this->assertTrue(file_exists('gaufrette://filestream/subdir'));
+        $this->assertTrue(is_dir('gaufrette://filestream/subdir'));
     }
 }


### PR DESCRIPTION
Fix #353.

It is now possible to call `file_exists` & `is_dir` on stream URI pointing
to a directory, whether it is hosted locally or remotely.