### PR TITLE
FIX High memory usage over time

### DIFF
--- a/src/Gaufrette/File.php
+++ b/src/Gaufrette/File.php
@@ -141,8 +141,10 @@ class File
     {
         $this->content = $content;
         $this->setMetadata($metadata);
+        $this->size = $this->filesystem->write($this->key, $this->content, true);
 
-        return $this->size = $this->filesystem->write($this->key, $this->content, true);
+        $this->content = null;
+        return $this->size;
     }
 
     /**


### PR DESCRIPTION
FIX Memory problems when creating images from an iterator or any kind of script that constantly uses this method.

Without this fix, creating 1000 images with a 0.6mb size, ended with 700mb script in memory, but it get worse, memory size increases over time significantly.

This fix makes constant (or almost) the memory usage. Script started with 395MB in memory, 4000 iterations later it's still 395MB and images are created perfectly.
