### PR TITLE
Wrap native dirname function in order to handle only UNIX-style paths

### DIFF
--- a/spec/Gaufrette/Util/PathSpec.php
+++ b/spec/Gaufrette/Util/PathSpec.php
@@ -23,4 +23,9 @@ class PathSpec extends ObjectBehavior
         $this->normalize('/home/other/./new')->shouldReturn('/home/other/new');
         $this->normalize('protocol://home/other.txt')->shouldReturn('protocol://home/other.txt');
     }
+
+    function it_returns_unix_style_dirname()
+    {
+        $this->dirname('a/test/path')->shouldReturn('a/test');
+    }
 }

--- a/src/Gaufrette/Adapter/AmazonS3.php
+++ b/src/Gaufrette/Adapter/AmazonS3.php
@@ -200,8 +200,8 @@ class AmazonS3 implements Adapter,
 
         $keys = array();
         foreach ($list as $file) {
-            if ('.' !== dirname($file)) {
-                $keys[] = dirname($file);
+            if ('.' !== \Gaufrette\Util\Path::dirname($file)) {
+                $keys[] = \Gaufrette\Util\Path::dirname($file);
             }
             $keys[] = $file;
         }

--- a/src/Gaufrette/Adapter/Dropbox.php
+++ b/src/Gaufrette/Adapter/Dropbox.php
@@ -137,8 +137,8 @@ class Dropbox implements Adapter
         foreach ($metadata['contents'] as $value) {
             $file = ltrim($value['path'], '/');
             $keys[] = $file;
-            if ('.' !== dirname($file)) {
-                $keys[] = dirname($file);
+            if ('.' !== \Gaufrette\Util\Path::dirname($file)) {
+                $keys[] = \Gaufrette\Util\Path::dirname($file);
             }
         }
         sort($keys);

--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -77,7 +77,7 @@ class Ftp implements Adapter,
         $this->ensureDirectoryExists($this->directory, $this->create);
 
         $path = $this->computePath($key);
-        $directory = str_replace('\\', '/', dirname($path));
+        $directory = str_replace('\\', '/', \Gaufrette\Util\Path::dirname($path));
 
         $this->ensureDirectoryExists($directory, true);
 
@@ -106,7 +106,7 @@ class Ftp implements Adapter,
         $sourcePath = $this->computePath($sourceKey);
         $targetPath = $this->computePath($targetKey);
 
-        $this->ensureDirectoryExists(str_replace('\\', '/', dirname($targetPath)), true);
+        $this->ensureDirectoryExists(str_replace('\\', '/', \Gaufrette\Util\Path::dirname($targetPath)), true);
 
         return ftp_rename($this->getConnection(), $sourcePath, $targetPath);
     }
@@ -119,7 +119,7 @@ class Ftp implements Adapter,
         $this->ensureDirectoryExists($this->directory, $this->create);
 
         $file  = $this->computePath($key);
-        $lines = ftp_rawlist($this->getConnection(), '-al ' . str_replace('\\', '/', dirname($file)));
+        $lines = ftp_rawlist($this->getConnection(), '-al ' . str_replace('\\', '/', \Gaufrette\Util\Path::dirname($file)));
 
         if (false === $lines) {
             return false;
@@ -273,7 +273,7 @@ class Ftp implements Adapter,
         $file = new File($key, $filesystem);
 
         if (!array_key_exists($key, $this->fileData)) {
-            $directory = dirname($key) == '.' ? '' : str_replace('\\', '/', dirname($key));
+            $directory = \Gaufrette\Util\Path::dirname($key) == '.' ? '' : str_replace('\\', '/', \Gaufrette\Util\Path::dirname($key));
             $this->listDirectory($directory);
         }
 
@@ -319,7 +319,7 @@ class Ftp implements Adapter,
     protected function createDirectory($directory)
     {
         // create parent directory if needed
-        $parent = str_replace('\\', '/', dirname($directory));
+        $parent = str_replace('\\', '/', \Gaufrette\Util\Path::dirname($directory));
         if (!$this->isDir($parent)) {
             $this->createDirectory($parent);
         }

--- a/src/Gaufrette/Adapter/Local.php
+++ b/src/Gaufrette/Adapter/Local.php
@@ -58,7 +58,7 @@ class Local implements Adapter,
     public function write($key, $content)
     {
         $path = $this->computePath($key);
-        $this->ensureDirectoryExists(dirname($path), true);
+        $this->ensureDirectoryExists(\Gaufrette\Util\Path::dirname($path), true);
 
         return file_put_contents($path, $content);
     }
@@ -69,7 +69,7 @@ class Local implements Adapter,
     public function rename($sourceKey, $targetKey)
     {
         $targetPath = $this->computePath($targetKey);
-        $this->ensureDirectoryExists(dirname($targetPath), true);
+        $this->ensureDirectoryExists(\Gaufrette\Util\Path::dirname($targetPath), true);
 
         return rename($this->computePath($sourceKey), $targetPath);
     }

--- a/src/Gaufrette/Adapter/PhpseclibSftp.php
+++ b/src/Gaufrette/Adapter/PhpseclibSftp.php
@@ -49,7 +49,7 @@ class PhpseclibSftp implements Adapter,
         $sourcePath = $this->computePath($sourceKey);
         $targetPath = $this->computePath($targetKey);
 
-        $this->ensureDirectoryExists(dirname($targetPath), true);
+        $this->ensureDirectoryExists(\Gaufrette\Util\Path::dirname($targetPath), true);
 
         return $this->sftp->rename($sourcePath, $targetPath);
     }
@@ -62,7 +62,7 @@ class PhpseclibSftp implements Adapter,
         $this->initialize();
 
         $path = $this->computePath($key);
-        $this->ensureDirectoryExists(dirname($path), true);
+        $this->ensureDirectoryExists(\Gaufrette\Util\Path::dirname($path), true);
         if ($this->sftp->put($path, $content)) {
             return $this->sftp->size($path);
         }

--- a/src/Gaufrette/Adapter/Sftp.php
+++ b/src/Gaufrette/Adapter/Sftp.php
@@ -46,7 +46,7 @@ class Sftp implements Adapter,
         $sourcePath = $this->computePath($sourceKey);
         $targetPath = $this->computePath($targetKey);
 
-        $this->ensureDirectoryExists(dirname($targetPath), true);
+        $this->ensureDirectoryExists(\Gaufrette\Util\Path::dirname($targetPath), true);
 
         return $this->sftp->rename($sourcePath, $targetPath);
     }
@@ -59,7 +59,7 @@ class Sftp implements Adapter,
         $this->initialize();
 
         $path = $this->computePath($key);
-        $this->ensureDirectoryExists(dirname($path), true);
+        $this->ensureDirectoryExists(\Gaufrette\Util\Path::dirname($path), true);
         $numBytes = $this->sftp->write($path, $content);
 
         return $numBytes;
@@ -101,8 +101,8 @@ class Sftp implements Adapter,
 
         $dirs = array();
         foreach ($files as $file) {
-            if ('.' !== dirname($file)) {
-                $dirs[] = dirname($file);
+            if ('.' !== \Gaufrette\Util\Path::dirname($file)) {
+                $dirs[] = \Gaufrette\Util\Path::dirname($file);
             }
         }
 

--- a/src/Gaufrette/Stream/Local.php
+++ b/src/Gaufrette/Stream/Local.php
@@ -29,7 +29,7 @@ class Local implements Stream
      */
     public function open(StreamMode $mode)
     {
-        $baseDirPath = dirname($this->path);
+        $baseDirPath = \Gaufrette\Util\Path::dirname($this->path);
         if ($mode->allowsWrite() && !is_dir($baseDirPath)) {
             @mkdir($baseDirPath, 0755, true);
         }

--- a/src/Gaufrette/Util/Path.php
+++ b/src/Gaufrette/Util/Path.php
@@ -72,4 +72,18 @@ class Path
 
         return strtolower($matches['prefix']);
     }
+
+    /**
+     * Wrap native dirname function in order to handle only UNIX-style paths
+     *
+     * @param string $path
+     *
+     * @return string
+     *
+     * @see http://php.net/manual/en/function.dirname.php
+     */
+    public static function dirname($path)
+    {
+        return str_replace('\\', '/', \dirname($path));
+    }
 }


### PR DESCRIPTION
As stated by php doc (http://php.net/manual/en/function.dirname.php), dirname
can return either slash or back-slash as directory separator.

It tries to fix problems on windows in a more generic way than #347 and #271.

Note that I don't have any windows system in order to test. I think we should wait AppVeyor integration before going further.