### PR TITLE
Updated new Azure namespaces.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
     "require": {
         "php": ">=5.4"
     },
+    "conflict": {
+        "microsoft/windowsazure": "<0.4.3"
+    },
     "require-dev": {
         "aws/aws-sdk-php": "~2",
         "amazonwebservices/aws-sdk-for-php": "1.5.*",

--- a/src/Gaufrette/Adapter/AzureBlobStorage.php
+++ b/src/Gaufrette/Adapter/AzureBlobStorage.php
@@ -5,11 +5,11 @@ namespace Gaufrette\Adapter;
 use Gaufrette\Adapter;
 use Gaufrette\Util;
 use Gaufrette\Adapter\AzureBlobStorage\BlobProxyFactoryInterface;
-use WindowsAzure\Blob\Models\CreateBlobOptions;
-use WindowsAzure\Blob\Models\CreateContainerOptions;
-use WindowsAzure\Blob\Models\DeleteContainerOptions;
-use WindowsAzure\Blob\Models\ListBlobsOptions;
-use WindowsAzure\Common\ServiceException;
+use MicrosoftAzure\Storage\Blob\Models\CreateBlobOptions;
+use MicrosoftAzure\Storage\Blob\Models\CreateContainerOptions;
+use MicrosoftAzure\Storage\Blob\Models\DeleteContainerOptions;
+use MicrosoftAzure\Storage\Blob\Models\ListBlobsOptions;
+use MicrosoftAzure\Storage\Common\ServiceException;
 
 /**
  * Microsoft Azure Blob Storage adapter.
@@ -42,7 +42,7 @@ class AzureBlobStorage implements Adapter,
     protected $detectContentType;
 
     /**
-     * @var \WindowsAzure\Blob\Internal\IBlob
+     * @var \MicrosoftAzure\Storage\Blob\Internal\IBlob
      */
     protected $blobProxy;
 
@@ -65,8 +65,8 @@ class AzureBlobStorage implements Adapter,
     /**
      * Creates a new container.
      *
-     * @param string                                           $containerName
-     * @param \WindowsAzure\Blob\Models\CreateContainerOptions $options
+     * @param string                                                     $containerName
+     * @param \MicrosoftAzure\Storage\Blob\Models\CreateContainerOptions $options
      *
      * @throws \RuntimeException if cannot create the container
      */

--- a/src/Gaufrette/Adapter/AzureBlobStorage/BlobProxyFactory.php
+++ b/src/Gaufrette/Adapter/AzureBlobStorage/BlobProxyFactory.php
@@ -2,7 +2,7 @@
 
 namespace Gaufrette\Adapter\AzureBlobStorage;
 
-use WindowsAzure\Common\ServicesBuilder;
+use MicrosoftAzure\Storage\Common\ServicesBuilder;
 
 /**
  * Basic implementation for a Blob proxy factory.

--- a/src/Gaufrette/Adapter/AzureBlobStorage/BlobProxyFactoryInterface.php
+++ b/src/Gaufrette/Adapter/AzureBlobStorage/BlobProxyFactoryInterface.php
@@ -12,7 +12,7 @@ interface BlobProxyFactoryInterface
     /**
      * Creates a new instance of the Blob proxy.
      *
-     * @return \WindowsAzure\Blob\Internal\IBlob
+     * @return \MicrosoftAzure\Storage\Blob\Internal\IBlob
      */
     public function create();
 }


### PR DESCRIPTION
Microsoft has changed the namespaces in the latest version of the azure-storage package (which has been split out from the SDK).
I updated the namespaces throughout the Gaufrette package, and also updated composer.json to add the conflict with previous versions of the azure SDK.
