### PR TITLE
Get content type by resource awsS3

### DIFF
--- a/src/Gaufrette/Util/Size.php
+++ b/src/Gaufrette/Util/Size.php
@@ -36,4 +36,18 @@ class Size
     {
         return filesize($filename);
     }
+
+    /**
+     * Returns the size in bytes from the given resource.
+     *
+     * @param resource $handle
+     *
+     * @return string
+     */
+    public static function fromResource($handle)
+    {
+        $cStat = fstat($handle);
+        // if the resource is a remote file, $cStat will be false
+        return $cStat ? $cStat['size'] : 0;
+    }
 }


### PR DESCRIPTION
Required when uploading streaming files such as video to awsS3.

Get content type by resource awsS3, Inspired by Pull-Request (Handle writing file by ressource as expected by Azure #398)
Return content size by resource awsS3, Inspired by Pull-Request (Handle writing file by ressource as expected by Azure #398)
Calculate size from resource, Inspired by Pull-Request (Handle writing file by ressource as expected by Azure #398)