### PR TITLE
Add a feature to get the name of the AWS Bucket

### DIFF
--- a/src/Gaufrette/Adapter/AmazonS3.php
+++ b/src/Gaufrette/Adapter/AmazonS3.php
@@ -239,6 +239,14 @@ class AmazonS3 implements Adapter,
     }
 
     /**
+     * Return the name of the bucket for this adapter.
+     */
+    public function getBucket()
+    {
+        return $this->bucket;
+    }
+
+    /**
      * Ensures the specified bucket exists. If the bucket does not exists
      * and the create parameter is set to true, it will try to create the
      * bucket.


### PR DESCRIPTION
This simply adds a way of exposing the bucket name from the adapter. This would be quite beneficial for me!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/knplabs/gaufrette/419)
<!-- Reviewable:end -->
