### PR TITLE
Modify FTP adapter to manage long paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name":         "knplabs/gaufrette",
+    "name":         "FaustineLarmagna/gaufrette",
     "type":         "library",
-    "description":  "PHP5 library that provides a filesystem abstraction layer",
+    "description":  "Fork of knplabs/gaufrette library: PHP5 library that provides a filesystem abstraction layer",
     "keywords":     ["file", "filesystem", "media", "abstraction"],
     "minimum-stability": "dev",
     "homepage":     "http://knplabs.com",

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,10 @@
         {
             "name":     "The contributors",
             "homepage": "http://github.com/knplabs/Gaufrette/contributors"
+        },
+        {
+            "name":     "Faustine Larmagna",
+            "homepage": "http://github.com/FausineLarmagna"
         }
     ],
     "repositories": [

--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -14,9 +14,9 @@ use Gaufrette\Exception;
  * @author  Antoine Hérault <antoine.herault@gmail.com>
  * @author <f.larmagna@gmail.com>
  */
-class FtpAdapter implements Adapter,
-                            FileFactory,
-                            ListKeysAware
+class Ftp implements Adapter,
+                     FileFactory,
+                     ListKeysAware
 {
     protected $connection = null;
     protected $directory;

--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -391,6 +391,8 @@ class Ftp implements Adapter,
      */
     private function isDir($directory)
     {
+        $currentPath = ftp_pwd($this->getConnection());
+
         if ('/' === $directory) {
             return true;
         }
@@ -399,8 +401,8 @@ class Ftp implements Adapter,
             return false;
         }
 
-        // change directory again to return in the base directory
-        ftp_chdir($this->getConnection(), $this->directory);
+        // change directory again to return to where we were
+        ftp_chdir($this->getConnection(), $currentPath);
 
         return true;
     }


### PR DESCRIPTION
In this pull request you will find the solution I used to fix an issue when dealing with too long file/directory paths: move the pointer to the directory containing the target file (or directory) before doing any FTP actions. And put the pointer back to where it was before the action afterwards.