### PR TITLE
Ftp Adapter: Use „Create Dir“ Parameter for Rename

### DIFF
--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -108,7 +108,7 @@ class Ftp implements Adapter,
         $sourcePath = $this->computePath($sourceKey);
         $targetPath = $this->computePath($targetKey);
 
-        $this->ensureDirectoryExists(\Gaufrette\Util\Path::dirname($targetPath));
+        $this->ensureDirectoryExists(\Gaufrette\Util\Path::dirname($targetPath), $this->create);
 
         return ftp_rename($this->getConnection(), $sourcePath, $targetPath);
     }


### PR DESCRIPTION
When I used the Rename Operation, I noticed that the SFTP Adapter automatically creates the new Directory if it doesn't exist, if the **create** option is `true`.

At the moment, FTP Adapter just throws an exception when the destination dir doesn't exist, even if the **create** flag is set.

This change basically makes the FTP Adapter rename like the SFTP Adapter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/knplabs/gaufrette/445)
<!-- Reviewable:end -->
