### PR TITLE
Touch cached file mod time once every $ttl interval

### DIFF
--- a/src/Gaufrette/Adapter/Cache.php
+++ b/src/Gaufrette/Adapter/Cache.php
@@ -211,8 +211,11 @@ class Cache implements Adapter,
                 if (time() - $this->ttl >= $dateCache) {
                     $dateSource = $this->source->mtime($key);
                     $needsReload = $dateCache < $dateSource;
-                    // touch file mod time so that we only check the source once per $ttl interval
-                    $this->cache->write($key, $this->cache->read($key));
+                    if (!$needsReload) {
+                        // we're not reloading from source now, but touch file mod time
+                        // so that we only check the source once per $ttl interval
+                        $this->cache->write($key, $this->cache->read($key));
+                    }
                 }
             } catch (\RuntimeException $e) {
             }

--- a/src/Gaufrette/Adapter/Cache.php
+++ b/src/Gaufrette/Adapter/Cache.php
@@ -211,6 +211,8 @@ class Cache implements Adapter,
                 if (time() - $this->ttl >= $dateCache) {
                     $dateSource = $this->source->mtime($key);
                     $needsReload = $dateCache < $dateSource;
+                    // touch file mod time so that we only check the source once per $ttl interval
+                    $this->cache->write($key, $this->cache->read($key));
                 }
             } catch (\RuntimeException $e) {
             }


### PR DESCRIPTION
As currently written, it seems like `(time() - $this->ttl >= $dateCache)` will return true for all values of `time()` that are `ttl` seconds after the cached file was created. This means that `source->mtime` will be queried for basically every file request (except the requests in the first `ttl` seconds after the cache is created.)

If the `source` is indeed laggy, you'd think it would take a long time to query `source->mtime`. So, the ttl feature should avoid checking the source except once per `ttl` interval.

I've coded a very hacky fix for this. Basically if we're not about to overwrite the file from source, we overwrite it from itself to reset the modification time. A similar effect could be achieved by `touch()`ing the file path but that's outside the concerns of `Cache.php` so I'll let you decide if this is worth committing.

In any case, a decent caching solution seems like it shouldn't be hitting the source every single time just to check modification dates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/knplabs/gaufrette/452)
<!-- Reviewable:end -->
