### PR TITLE
Use docker to ease testability across php versions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.idea/
+bin/tests-all
+doc/
+docker/
+vendor/
+.dockerignore
+.editorconfig
+.gitignore
+.travis.yml
+appveyor.yml
+composer.lock
+docker-compose.yml
+LICENSE
+README.md

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
+bin/*
+!bin/tests
+!bin/tests-all
+doc/.couscous
+tests/adapters/*
+!tests/adapters/*.dist
 vendor/
 composer.lock
 phpunit.xml
-tests/adapters/*
-!tests/adapters/*.dist
-bin/*
-!bin/configure_test_env.sh
-doc/.couscous

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ before_script:
   - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.4" ]]; then composer require microsoft/windowsazure:^0.4.3; fi
 
 script:
-  - php bin/phpspec run -fpretty --verbose
-  - php bin/phpunit
+  - php vendor/bin/phpspec run -fpretty --verbose
+  - php vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -33,27 +33,19 @@ Read the official [Gaufrette documentation](http://knplabs.github.io/Gaufrette/)
 
 Symfony integration is available through [KnpLabs/KnpGaufretteBundle](https://github.com/KnpLabs/KnpGaufretteBundle).
 
-### Setup the vendor libraries
-
-As some filesystem adapters use vendor libraries, you should install the vendors:
-
-    $ composer install
-    $ composer require microsoft/windowsazure # Needs php >= 5.5
-    $ sh bin/configure_test_env.sh
-
-It will avoid skip a lot of tests.
-
 ### Launch the Test Suite
 
-In the Gaufrette root directory:
+Requires:
+  * docker
+  * docker-compose
 
-To check if classes specification pass:
+Build images:
 
-    $ php bin/phpspec run
+    $ docker-compose build
 
-To check basic functionality of the adapters (adapters should be configured you will see many skipped tests):
+Launch the tests:
 
-    $ bin/phpunit
+    $ bin/tests-all
 
 Is it green?
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,5 +27,5 @@ install:
 
 test_script:
   - cd C:\projects\gaufrette
-  - php bin\phpspec.bat run -fpretty --verbose
-  - php bin\phpunit.bat
+  - php vendor\bin\phpspec.bat run -fpretty --verbose
+  - php vendor\bin\phpunit.bat

--- a/bin/tests
+++ b/bin/tests
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o xtrace
+
+DIR=$(dirname ${BASH_SOURCE[0]})/..
+
+cp \
+    ${DIR}/tests/Gaufrette/Functional/adapters/DoctrineDbal.php.dist \
+    ${DIR}/tests/Gaufrette/Functional/adapters/DoctrineDbal.php
+
+${DIR}/vendor/bin/phpspec run --format=pretty
+${DIR}/vendor/bin/phpunit

--- a/bin/tests-all
+++ b/bin/tests-all
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -o xtrace
+
+docker-compose run --rm php54
+docker-compose run --rm php55
+docker-compose run --rm php56
+docker-compose run --rm php70
+docker-compose run --rm php71
+docker-compose run --rm hhvm

--- a/composer.json
+++ b/composer.json
@@ -68,8 +68,5 @@
         "branch-alias": {
             "dev-master": "0.4.x-dev"
         }
-    },
-    "config": {
-        "bin-dir": "bin"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,9 @@
         "microsoft/windowsazure": "<0.4.3"
     },
     "require-dev": {
-        "aws/aws-sdk-php": "~2",
+        "aws/aws-sdk-php": "^2.4.12",
         "amazonwebservices/aws-sdk-for-php": "1.5.*",
-        "rackspace/php-opencloud"  : "1.9.*",
+        "rackspace/php-opencloud"  : "^1.9.2",
         "google/apiclient": "~1.1.3",
         "phpspec/phpspec": "~2.4",
         "phpseclib/phpseclib": "^2.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '2'
+
+services:
+  php54:
+    build:
+        context: .
+        dockerfile: docker/Dockerfile-php54
+
+  php55:
+    build:
+        context: .
+        dockerfile: docker/Dockerfile-php55
+
+  php56:
+    build:
+        context: .
+        dockerfile: docker/Dockerfile-php56
+
+  php70:
+    build:
+        context: .
+        dockerfile: docker/Dockerfile-php70
+
+  php71:
+    build:
+        context: .
+        dockerfile: docker/Dockerfile-php71
+
+  hhvm:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile-hhvm

--- a/docker/Dockerfile-hhvm
+++ b/docker/Dockerfile-hhvm
@@ -1,0 +1,16 @@
+FROM webdevops/hhvm:ubuntu-16.04
+
+ENV SRC_DIR /usr/src/gaufrette
+WORKDIR ${SRC_DIR}
+
+COPY composer.json ${SRC_DIR}/
+RUN composer global require hirak/prestissimo && \
+    composer remove --dev --no-update herzult/php-ssh && \
+    composer update --prefer-lowest --prefer-stable && \
+    composer require microsoft/windowsazure:~0.5 && \
+    rm -rf ~/.composer/cache/*
+
+VOLUME ${SRC_DIR}/vendor
+
+COPY . ${SRC_DIR}/
+CMD "${SRC_DIR}/bin/tests"

--- a/docker/Dockerfile-php54
+++ b/docker/Dockerfile-php54
@@ -1,0 +1,22 @@
+FROM jolicode/php54:latest
+
+ENV SRC_DIR /usr/src/gaufrette
+WORKDIR ${SRC_DIR}/
+
+RUN sudo apt-get update && \
+    sudo apt-get install -y libssh2-1-dev && \
+    sudo rm -rf /var/lib/apt/lists/* && \
+    pecl install mongo ssh2
+
+COPY composer.json ${SRC_DIR}/
+RUN sudo chown -R travis ${SRC_DIR} && \
+    composer global require hirak/prestissimo && \
+    composer install --prefer-dist && \
+    rm -rf ~/.composer/cache/*
+
+VOLUME ${SRC_DIR}/vendor
+
+COPY . ${SRC_DIR}/
+RUN sudo chown -R travis ${SRC_DIR}
+
+CMD "${SRC_DIR}/bin/tests"

--- a/docker/Dockerfile-php55
+++ b/docker/Dockerfile-php55
@@ -1,0 +1,22 @@
+FROM jolicode/php55:latest
+
+ENV SRC_DIR /usr/src/gaufrette
+WORKDIR ${SRC_DIR}/
+
+RUN sudo apt-get update && \
+    sudo apt-get install -y libssh2-1-dev && \
+    sudo rm -rf /var/lib/apt/lists/* && \
+    pecl install mongo ssh2
+
+COPY composer.json ${SRC_DIR}/
+RUN sudo chown -R travis ${SRC_DIR} && \
+    composer global require hirak/prestissimo && \
+    composer install --prefer-dist && \
+    rm -rf ~/.composer/cache/*
+
+VOLUME ${SRC_DIR}/vendor
+
+COPY . ${SRC_DIR}/
+RUN sudo chown -R travis ${SRC_DIR}
+
+CMD "${SRC_DIR}/bin/tests"

--- a/docker/Dockerfile-php56
+++ b/docker/Dockerfile-php56
@@ -1,0 +1,23 @@
+FROM jolicode/php56:latest
+
+ENV SRC_DIR /usr/src/gaufrette
+WORKDIR ${SRC_DIR}/
+
+RUN sudo apt-get update && \
+    sudo apt-get install -y libssh2-1-dev && \
+    sudo rm -rf /var/lib/apt/lists/* && \
+    pecl install mongo ssh2
+
+COPY composer.json ${SRC_DIR}/
+RUN sudo chown -R travis ${SRC_DIR} && \
+    composer global require hirak/prestissimo && \
+    composer update --prefer-lowest --prefer-stable && \
+    composer require microsoft/windowsazure:~0.4.3 && \
+    rm -rf ~/.composer/cache/*
+
+VOLUME ${SRC_DIR}/vendor
+
+COPY . ${SRC_DIR}/
+RUN sudo chown -R travis ${SRC_DIR}
+
+CMD "${SRC_DIR}/bin/tests"

--- a/docker/Dockerfile-php70
+++ b/docker/Dockerfile-php70
@@ -1,0 +1,28 @@
+FROM php:7.0-cli
+
+ENV SRC_DIR /usr/src/gaufrette
+WORKDIR ${SRC_DIR}
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        libssh2-1-dev \
+        libssl-dev \
+        unzip \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/* && \
+    pecl install mongodb ssh2-alpha zip && \
+    echo 'extension=/usr/local/lib/php/extensions/no-debug-non-zts-20151012/mongodb.so' >> /usr/local/etc/php/conf.d/mongodb.ini && \
+    echo 'extension=/usr/local/lib/php/extensions/no-debug-non-zts-20151012/ssh2.so' >> /usr/local/etc/php/conf.d/ssh2.ini && \
+    echo 'extension=/usr/local/lib/php/extensions/no-debug-non-zts-20151012/zip.so' >> /usr/local/etc/php/conf.d/zip.ini
+
+COPY composer.json ${SRC_DIR}/
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    composer install && \
+    composer require microsoft/windowsazure:dev-master && \
+    rm -rf ~/.composer/cache/*
+
+VOLUME ${SRC_DIR}/vendor
+
+COPY . ${SRC_DIR}/
+CMD "${SRC_DIR}/bin/tests"

--- a/docker/Dockerfile-php71
+++ b/docker/Dockerfile-php71
@@ -1,0 +1,29 @@
+FROM php:7.1-cli
+
+ENV SRC_DIR /usr/src/gaufrette
+WORKDIR ${SRC_DIR}
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        libssh2-1-dev \
+        libssl-dev \
+        unzip \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/* && \
+    pecl install mongodb ssh2-alpha zip && \
+    echo 'extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/mongodb.so' >> /usr/local/etc/php/conf.d/mongodb.ini && \
+    echo 'extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/ssh2.so' >> /usr/local/etc/php/conf.d/ssh2.ini && \
+    echo 'extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/zip.so' >> /usr/local/etc/php/conf.d/zip.ini
+
+COPY composer.json ${SRC_DIR}/
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    composer global require hirak/prestissimo && \
+    composer update --prefer-lowest --prefer-stable && \
+    composer require microsoft/windowsazure:~0.5 && \
+    rm -rf ~/.composer/cache/*
+
+VOLUME ${SRC_DIR}/vendor
+
+COPY . ${SRC_DIR}/
+CMD "${SRC_DIR}/bin/tests"


### PR DESCRIPTION
This PR adds a docker container for every php versions currently supported (5.4, 5.5, 5.6) & php 7.0/7.1. It will help maintainers to (locally) execute tests across php versions.

For now, Travis builds are not based on these containers. AFAIK we would need to drop the matrix and replace it with a single job testing every supported php versions. I've already made a test, [available here](https://travis-ci.org/KnpLabs/Gaufrette/builds/210317261). Currently, I see two minor drawbacks: build time will be higher and job logs readability.