### PR TITLE
Upgrade aws-sdk-php to v3

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,6 @@
+AWS_KEY=
+AWS_SECRET=
+AWS_BUCKET=
+
+MONGO_URI=mongodb://mongodb:27017
+MONGO_DBNAME=gridfs_test

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ doc/.couscous
 tests/adapters/*
 !tests/adapters/*.dist
 vendor/
+.env
 composer.lock
 phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
+env:
+  global:
+    - AWS_KEY:
+    - AWS_SECRET:
+
 php:
   - 5.6
   - hhvm

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,13 @@ branches:
 cache:
   - '%LOCALAPPDATA%\Composer\files'
 
+environment:
+  AWS_KEY:
+    secure: nMVfvhojgVc9VBlrYXeddaYIQHlVAlupWmxNjXMlsB0=
+  AWS_SECRET:
+    secure: MiAf2q7mnqSIZSoChd9v3pwUrXHeAEpZP8Zc0E0qjiOBXPvplzJVtrkWRwTNlQl3
+  AWS_BUCKET: gaufretteci
+
 init:
   - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "microsoft/windowsazure": "<0.4.3"
     },
     "require-dev": {
-        "aws/aws-sdk-php": "^2.4.12",
+        "aws/aws-sdk-php": "^2.4.12||~3",
         "amazonwebservices/aws-sdk-for-php": "1.5.*",
         "rackspace/php-opencloud"  : "^1.9.2",
         "google/apiclient": "~1.1.3",

--- a/doc/adapters/aws-s3.md
+++ b/doc/adapters/aws-s3.md
@@ -18,14 +18,14 @@ use Aws\S3\S3Client;
 use Gaufrette\Adapter\AwsS3 as AwsS3Adapter;
 use Gaufrette\Filesystem;
 
-$s3client = S3Client::factory(array(
+$s3client = new S3Client([
     'credentials' => array(
         'key'     => 'your_key_here',
         'secret'  => 'your_secret',
     ),
     'version' => 'latest',
     'region'  => 'eu-west-1',
-));
+]);
 $adapter = new AwsS3Adapter($s3client,'your-bucket-name');
 $filesystem = new Filesystem($adapter);
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+
 version: '2'
 
 services:
@@ -9,6 +10,7 @@ services:
       - './spec/:/usr/src/gaufrette/spec/'
       - './src/:/usr/src/gaufrette/src/'
       - './tests/:/usr/src/gaufrette/tests/'
+    env_file: .env
 
   php55:
     build:
@@ -18,6 +20,7 @@ services:
       - './spec/:/usr/src/gaufrette/spec/'
       - './src/:/usr/src/gaufrette/src/'
       - './tests/:/usr/src/gaufrette/tests/'
+    env_file: .env
 
   php56:
     build:
@@ -27,11 +30,9 @@ services:
       - './spec/:/usr/src/gaufrette/spec/'
       - './src/:/usr/src/gaufrette/src/'
       - './tests/:/usr/src/gaufrette/tests/'
-    environment:
-      MONGO_URI: "mongodb://mongodb:27017"
-      MONGO_DBNAME: "gridfs_test"
     depends_on:
       - mongodb
+    env_file: .env
 
   php70:
     build:
@@ -41,12 +42,9 @@ services:
       - './spec/:/usr/src/gaufrette/spec/'
       - './src/:/usr/src/gaufrette/src/'
       - './tests/:/usr/src/gaufrette/tests/'
-    environment:
-      MONGO_URI: "mongodb://mongodb:27017"
-      MONGO_DBNAME: "gridfs_test"
     depends_on:
       - mongodb
-
+    env_file: .env
 
   php71:
     build:
@@ -56,9 +54,7 @@ services:
       - './spec/:/usr/src/gaufrette/spec/'
       - './src/:/usr/src/gaufrette/src/'
       - './tests/:/usr/src/gaufrette/tests/'
-    environment:
-      MONGO_URI: "mongodb://mongodb:27017"
-      MONGO_DBNAME: "gridfs_test"
+    env_file: .env
     depends_on:
       - mongodb
 
@@ -70,9 +66,7 @@ services:
       - './spec/:/usr/src/gaufrette/spec/'
       - './src/:/usr/src/gaufrette/src/'
       - './tests/:/usr/src/gaufrette/tests/'
-    environment:
-      MONGO_URI: "mongodb://mongodb:27017"
-      MONGO_DBNAME: "gridfs_test"
+    env_file: .env
     depends_on:
       - mongodb
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,10 @@
         <!-- Parameters for GridFS adapter -->
         <!--<env name="MONGO_URI" value="mongodb://localhost:27017" />
         <env name="MONGO_DBNAME" value="gridfs_test" />-->
+
+        <!-- Configuration for AwsS3 adapter -->
+        <!--<env name="AWS_SECRET" value="" />
+        <env name="AWS_KEY" value="" />-->
     </php>
 
     <testsuites>


### PR DESCRIPTION
We're stuck with guzzle/guzzle which is abandoned, because of aws-sdk-php v2.
Hence we need to allow aws-sdk-php v3 which relies on guzzlehttp/guzzle v5/v6.