### PR TITLE
Don't use FTP_USEPASSVADDRESS before php 5.6.18

### DIFF
--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -528,7 +528,7 @@ class Ftp implements Adapter,
             $this->connection = ftp_ssl_connect($this->host, $this->port, $this->timeout);
         }
 
-        if (PHP_VERSION_ID >= 50600) {
+        if (PHP_VERSION_ID >= 50618) {
             ftp_set_option($this->connection, FTP_USEPASVADDRESS, false);
         }
 


### PR DESCRIPTION
See https://github.com/php/php-src/commit/90a26a4844d1acfecb3bd0842da333f8bddd45c6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/knplabs/gaufrette/477)
<!-- Reviewable:end -->
