### PR TITLE
Enable FTP_USEPASVADDRESS option only if the constant exists

### DIFF
--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -528,7 +528,7 @@ class Ftp implements Adapter,
             $this->connection = ftp_ssl_connect($this->host, $this->port, $this->timeout);
         }
 
-        if (PHP_VERSION_ID >= 50618) {
+        if (defined('FTP_USEPASVADDRESS')) {
             ftp_set_option($this->connection, FTP_USEPASVADDRESS, false);
         }
 


### PR DESCRIPTION
As stated by @stof in #477, FTP_USEPASVADDRESS is also not supported
by PHP 7.0.0 & 7.0.1. See php/php-src@90a26a4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/knplabs/gaufrette/480)
<!-- Reviewable:end -->
