### PR TITLE
Move away setUp/tearDown logic from AwsS3Test to a dedicated trait

### DIFF
--- a/tests/Gaufrette/Functional/Adapter/AwsS3SetUpTearDownTrait.php
+++ b/tests/Gaufrette/Functional/Adapter/AwsS3SetUpTearDownTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Gaufrette\Functional\Adapter;
+
+use Aws\S3\S3Client;
+
+trait AwsS3SetUpTearDownTrait
+{
+    /** @var S3Client */
+    private $client;
+
+    /** @var string */
+    private $bucket;
+
+    /** @var string */
+    private $region;
+
+    public function setUp()
+    {
+        $key    = getenv('AWS_KEY');
+        $secret = getenv('AWS_SECRET');
+        $region = getenv('AWS_REGION');
+
+        if (empty($key) || empty($secret)) {
+            $this->markTestSkipped('Missing AWS_KEY and/or AWS_SECRET env vars.');
+        }
+
+        $this->bucket = uniqid(getenv('AWS_BUCKET'));
+        $this->region = $region ? $region : 'eu-west-1';
+
+        if (self::$SDK_VERSION === 3) {
+            // New way of instantiating S3Client for aws-sdk-php v3
+            $this->client = new S3Client([
+                'region' => $this->region,
+                'version' => 'latest',
+                'credentials' => [
+                    'key' => $key,
+                    'secret' => $secret,
+                ],
+            ]);
+        } else {
+            $this->client = S3Client::factory([
+                'region' => $this->region,
+                'version' => '2006-03-01',
+                'key' => $key,
+                'secret' => $secret,
+            ]);
+        }
+    }
+
+    public function tearDown()
+    {
+        if ($this->client === null || !$this->client->doesBucketExist($this->bucket)) {
+            return;
+        }
+
+        $result = $this->client->listObjects(['Bucket' => $this->bucket]);
+        $staleObjects = $result->get('Contents');
+
+        foreach ($staleObjects as $staleObject) {
+            $this->client->deleteObject(['Bucket' => $this->bucket, 'Key' => $staleObject['Key']]);
+        }
+
+        $this->client->deleteBucket(['Bucket' => $this->bucket]);
+    }
+}

--- a/tests/Gaufrette/Functional/Adapter/AwsS3Test.php
+++ b/tests/Gaufrette/Functional/Adapter/AwsS3Test.php
@@ -11,65 +11,10 @@ use Gaufrette\Filesystem;
  */
 class AwsS3Test extends \PHPUnit_Framework_TestCase
 {
+    use AwsS3SetUpTearDownTrait;
+
     /** @var int */
     static private $SDK_VERSION;
-
-    /** @var string */
-    private $bucket;
-
-    /** @var S3Client */
-    private $client;
-
-    public function setUp()
-    {
-        $key = getenv('AWS_KEY');
-        $secret = getenv('AWS_SECRET');
-
-        if (empty($key) || empty($secret)) {
-            $this->markTestSkipped();
-        }
-
-        if (self::$SDK_VERSION === null) {
-            self::$SDK_VERSION = method_exists(S3Client::class, 'getArguments') ? 3 : 2;
-        }
-
-        $this->bucket = uniqid(getenv('AWS_BUCKET'));
-
-        if (self::$SDK_VERSION === 3) {
-            // New way of instantiating S3Client for aws-sdk-php v3
-            $this->client = new S3Client([
-                'region' => 'eu-west-1',
-                'version' => 'latest',
-                'credentials' => [
-                    'key' => $key,
-                    'secret' => $secret,
-                ],
-            ]);
-        } else {
-            $this->client = S3Client::factory([
-                'region' => 'eu-west-1',
-                'version' => '2006-03-01',
-                'key' => $key,
-                'secret' => $secret,
-            ]);
-        }
-    }
-
-    public function tearDown()
-    {
-        if ($this->client === null || !$this->client->doesBucketExist($this->bucket)) {
-            return;
-        }
-
-        $result = $this->client->listObjects(['Bucket' => $this->bucket]);
-        $staleObjects = $result->get('Contents');
-
-        foreach ($staleObjects as $staleObject) {
-            $this->client->deleteObject(['Bucket' => $this->bucket, 'Key' => $staleObject['Key']]);
-        }
-
-        $this->client->deleteBucket(['Bucket' => $this->bucket]);
-    }
 
     private function getFilesystem(array $adapterOptions = [])
     {


### PR DESCRIPTION
It would ease writing functional tests for people who wants to extend Gaufrette behaviors.
For instance, [Gaufrette/extras](https://github.com/Gaufrette/extras) would benefit this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/knplabs/gaufrette/494)
<!-- Reviewable:end -->
