### PR TITLE
Fix parse_url() invalid behavior with UTF-8

### DIFF
--- a/src/Gaufrette/StreamWrapper.php
+++ b/src/Gaufrette/StreamWrapper.php
@@ -2,6 +2,8 @@
 
 namespace Gaufrette;
 
+use Gaufrette\Util\Path;
+
 /**
  * Stream wrapper class for the Gaufrette filesystems.
  *
@@ -250,7 +252,7 @@ class StreamWrapper
                 'query' => null,
                 'fragment' => null,
             ),
-            parse_url($path) ?: array()
+            Path::parseUrl($path) ?: array()
         );
 
         $domain = $parts['host'];

--- a/src/Gaufrette/Util/Path.php
+++ b/src/Gaufrette/Util/Path.php
@@ -86,4 +86,39 @@ class Path
     {
         return str_replace('\\', '/', \dirname($path));
     }
+
+    /**
+     * UTF-8 aware parse_url() replacement.
+     *
+     * @param string $url to parse
+     *
+     * @return bool|array
+     *
+     * @see https://secure.php.net/manual/function.parse-url.php#114817
+     */
+    public static function parseUrl($url)
+    {
+        $encodedUrl = preg_replace_callback(
+            '%[^:/@?&=#]+%usD',
+            function ($matches)
+            {
+                return urlencode($matches[0]);
+            },
+            $url
+        );
+
+        $parts = parse_url($encodedUrl);
+
+        if (false === $parts)
+        {
+            return false;
+        }
+
+        foreach ($parts as $name => $value)
+        {
+            $parts[$name] = urldecode($value);
+        }
+
+        return $parts;
+    }
 }

--- a/tests/Gaufrette/Functional/FileStream/FunctionalTestCase.php
+++ b/tests/Gaufrette/Functional/FileStream/FunctionalTestCase.php
@@ -200,6 +200,31 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
         $this->assertTrue(file_exists('gaufrette://filestream/test.txt'));
     }
 
+    /**
+     * @test
+     */
+    public function shouldHandleFilesWithSpecialCharacters()
+    {
+        $strings = [
+            'ñóǹ äŝçíì',
+            '汉语漢語',
+            '华语華語',
+            'Huáyǔ;',
+            '中文',
+            'Zhōngwén',
+            '漢字仮名交じり文',
+            'Lech Wałęsa',
+            'æøå',
+        ];
+        foreach ($strings as $string) {
+            $this->filesystem->write("$string.txt", 'some content');
+            $this->assertTrue(is_file("gaufrette://filestream/$string.txt"));
+
+            $this->filesystem->delete("$string.txt");
+            $this->assertFalse(is_file("gaufrette://filestream/$string.txt"));
+        }
+    }
+
     public static function modesProvider()
     {
         return array(

--- a/tests/Gaufrette/Unit/Util/PathTest.php
+++ b/tests/Gaufrette/Unit/Util/PathTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Gaufrette\Unit\Util;
+
+use Gaufrette\Util\Path;
+
+/**
+ * Path test.
+ *
+ * @coversDefaultClass Gaufrette\Util\Path
+ */
+class PathTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @covers ::parseUrl
+     */
+    public function shouldParseUrlCorrectly()
+    {
+        $url = 'gaufrette://föô/bàr?bäz=1#qùx';
+        $expected = [
+            'scheme' => 'gaufrette',
+            'host' => 'föô',
+            'path' => '/bàr',
+            'query' => 'bäz=1',
+            'fragment' => 'qùx',
+        ];
+        $parts = Path::parseUrl($url);
+
+        $this->assertEquals($expected, $parts);
+    }
+
+    /**
+     * @test
+     * @covers ::parseUrl
+     */
+    public function shouldReturnFalseWhenParsingMalformedUrl()
+    {
+        $url = ':';
+        $expected = false;
+        $parts = Path::parseUrl($url);
+
+        $this->assertEquals($expected, $parts);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | this fixes #507
| License       | MIT