### PR TITLE
Ignore errors during installation of ssh2 extension

### DIFF
--- a/bin/tests
+++ b/bin/tests
@@ -6,9 +6,5 @@ set -o xtrace
 
 DIR=$(dirname ${BASH_SOURCE[0]})/..
 
-cp \
-    ${DIR}/tests/Gaufrette/Functional/adapters/DoctrineDbal.php.dist \
-    ${DIR}/tests/Gaufrette/Functional/adapters/DoctrineDbal.php
-
 ${DIR}/vendor/bin/phpspec run --format=pretty
 ${DIR}/vendor/bin/phpunit

--- a/docker/Dockerfile-php71
+++ b/docker/Dockerfile-php71
@@ -11,7 +11,8 @@ RUN apt-get update && \
         unzip \
         libzip-dev \
     && rm -rf /var/lib/apt/lists/* && \
-    pecl install mongodb ssh2-alpha zip && \
+    pecl install mongodb zip && \
+    pecl install --ignore-errors ssh2-alpha && \
     echo 'extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/mongodb.so' >> /usr/local/etc/php/conf.d/mongodb.ini && \
     echo 'extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/ssh2.so' >> /usr/local/etc/php/conf.d/ssh2.ini && \
     echo 'extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/zip.so' >> /usr/local/etc/php/conf.d/zip.ini


### PR DESCRIPTION
As mentioned in [this bug report](https://bugs.php.net/bug.php?id=74787), ssh2 v1.1 (and v1.1.1) does not provide the `tests/` folder, thus pecl refuses to install it.

Closes #509.