### PR TITLE
Fix incomplete tear down phase for AwsS3Test

### DIFF
--- a/tests/Gaufrette/Functional/Adapter/AwsS3Test.php
+++ b/tests/Gaufrette/Functional/Adapter/AwsS3Test.php
@@ -63,6 +63,7 @@ class AwsS3Test extends FunctionalTestCase
         $result = $this->client->listObjects(['Bucket' => $this->bucket]);
 
         if (!$result->hasKey('Contents')) {
+            $this->client->deleteBucket(['Bucket' => $this->bucket]);
             return;
         }
 


### PR DESCRIPTION
Since some days functionnal tests for AwsS3 are broken from time to time.
That's because the adapter creates buckets never deleted during tear down
phase and because AWS allows at most 100 buckets at the same time.

Also, I created a little cleanup script [available here](https://gist.github.com/NiR-/c9ceb18ae334e807c23f7a4ec79aff98).