### PR TITLE
Introduce StorageFailure and FileNotFound exceptions

### DIFF
--- a/src/Gaufrette/Adapter.php
+++ b/src/Gaufrette/Adapter.php
@@ -2,6 +2,7 @@
 
 namespace Gaufrette;
 
+use Gaufrette\Exception\FileNotFound;
 use Gaufrette\Exception\StorageFailure;
 
 /**
@@ -19,6 +20,7 @@ interface Adapter
      *
      * @return string
      *
+     * @throws FileNotFound
      * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function read($key);
@@ -62,6 +64,7 @@ interface Adapter
      *
      * @return int An UNIX like timestamp
      *
+     * @throws FileNotFound
      * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function mtime($key);
@@ -71,6 +74,7 @@ interface Adapter
      *
      * @param string $key
      *
+     * @throws FileNotFound
      * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function delete($key);
@@ -81,7 +85,7 @@ interface Adapter
      * @param string $sourceKey
      * @param string $targetKey
      *
-     * 
+     * @throws FileNotFound
      * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function rename($sourceKey, $targetKey);

--- a/src/Gaufrette/Adapter.php
+++ b/src/Gaufrette/Adapter.php
@@ -2,6 +2,8 @@
 
 namespace Gaufrette;
 
+use Gaufrette\Exception\StorageFailure;
+
 /**
  * Interface for the filesystem adapters.
  *
@@ -15,7 +17,9 @@ interface Adapter
      *
      * @param string $key
      *
-     * @return string|bool if cannot read content
+     * @return string
+     *
+     * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function read($key);
 
@@ -25,7 +29,9 @@ interface Adapter
      * @param string $key
      * @param string $content
      *
-     * @return int|bool The number of bytes that were written into the file
+     * @return int The number of bytes that were written into the file
+     *
+     * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function write($key, $content);
 
@@ -35,6 +41,8 @@ interface Adapter
      * @param string $key
      *
      * @return bool
+     *
+     * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function exists($key);
 
@@ -42,6 +50,8 @@ interface Adapter
      * Returns an array of all keys (files and directories).
      *
      * @return array
+     *
+     * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function keys();
 
@@ -50,7 +60,9 @@ interface Adapter
      *
      * @param string $key
      *
-     * @return int|bool An UNIX like timestamp or false
+     * @return int An UNIX like timestamp
+     *
+     * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function mtime($key);
 
@@ -59,7 +71,7 @@ interface Adapter
      *
      * @param string $key
      *
-     * @return bool
+     * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function delete($key);
 
@@ -69,7 +81,8 @@ interface Adapter
      * @param string $sourceKey
      * @param string $targetKey
      *
-     * @return bool
+     * 
+     * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function rename($sourceKey, $targetKey);
 
@@ -79,6 +92,8 @@ interface Adapter
      * @param string $key
      *
      * @return bool
+     *
+     * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function isDirectory($key);
 }

--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -5,6 +5,7 @@ namespace Gaufrette\Adapter;
 use Aws\S3\Exception\S3Exception;
 use Gaufrette\Adapter;
 use Aws\S3\S3Client;
+use Gaufrette\Exception\FileNotFound;
 use Gaufrette\Exception\StorageFailure;
 use Gaufrette\Util;
 
@@ -96,6 +97,10 @@ class AwsS3 implements Adapter,
 
             return (string) $object->get('Body');
         } catch (\Exception $e) {
+            if ($e instanceof S3Exception && $e->getResponse()->getStatusCode() === 404) {
+                throw new FileNotFound($key);
+            }
+
             throw StorageFailure::unexpectedFailure('read', ['key' => $key], $e);
         }
     }
@@ -116,6 +121,10 @@ class AwsS3 implements Adapter,
 
             return $this->delete($sourceKey);
         } catch (\Exception $e) {
+            if ($e instanceof S3Exception && $e->getResponse()->getStatusCode() === 404) {
+                throw new FileNotFound($sourceKey);
+            }
+
             throw StorageFailure::unexpectedFailure(
                 'rename',
                 ['sourceKey' => $sourceKey, 'targetKey' => $targetKey],
@@ -181,6 +190,10 @@ class AwsS3 implements Adapter,
 
             return strtotime($result['LastModified']);
         } catch (\Exception $e) {
+            if ($e instanceof S3Exception && $e->getResponse()->getStatusCode() === 404) {
+                throw new FileNotFound($key);
+            }
+
             throw StorageFailure::unexpectedFailure('mtime', ['key' => $key], $e);
         }
     }
@@ -195,6 +208,10 @@ class AwsS3 implements Adapter,
 
             return $result['ContentLength'];
         } catch (\Exception $e) {
+            if ($e instanceof S3Exception && $e->getResponse()->getStatusCode() === 404) {
+                throw new FileNotFound($key);
+            }
+
             throw StorageFailure::unexpectedFailure('size', ['key' => $key], $e);
         }
     }
@@ -243,6 +260,10 @@ class AwsS3 implements Adapter,
 
             return true;
         } catch (\Exception $e) {
+            if ($e instanceof S3Exception && $e->getResponse()->getStatusCode() === 404) {
+                throw new FileNotFound($key);
+            }
+
             throw StorageFailure::unexpectedFailure('delete', ['key' => $key], $e);
         }
     }
@@ -354,6 +375,10 @@ class AwsS3 implements Adapter,
             $result = $this->service->headObject($this->getOptions($key));
             return ($result['ContentType']);
         } catch (\Exception $e) {
+            if ($e instanceof S3Exception && $e->getResponse()->getStatusCode() === 404) {
+                throw new FileNotFound($key);
+            }
+
             throw StorageFailure::unexpectedFailure('mimeType', ['key' => $key], $e);
         }
     }

--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -52,6 +52,9 @@ class AwsS3 implements Adapter,
             $options
         );
 
+        // Remove trailing slash so it can't be doubled in computePath() method
+        $this->options['directory'] = rtrim($this->options['directory'], '/');
+
         $this->detectContentType = $detectContentType;
     }
 

--- a/src/Gaufrette/Adapter/ChecksumCalculator.php
+++ b/src/Gaufrette/Adapter/ChecksumCalculator.php
@@ -2,6 +2,8 @@
 
 namespace Gaufrette\Adapter;
 
+use Gaufrette\Exception\StorageFailure;
+
 /**
  * Interface which add checksum calculation support to adapter.
  *
@@ -15,6 +17,8 @@ interface ChecksumCalculator
      * @param string $key
      *
      * @return string
+     *
+     * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function checksum($key);
 }

--- a/src/Gaufrette/Adapter/ChecksumCalculator.php
+++ b/src/Gaufrette/Adapter/ChecksumCalculator.php
@@ -2,6 +2,7 @@
 
 namespace Gaufrette\Adapter;
 
+use Gaufrette\Exception\FileNotFound;
 use Gaufrette\Exception\StorageFailure;
 
 /**
@@ -18,6 +19,7 @@ interface ChecksumCalculator
      *
      * @return string
      *
+     * @throws FileNotFound
      * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function checksum($key);

--- a/src/Gaufrette/Adapter/ListKeysAware.php
+++ b/src/Gaufrette/Adapter/ListKeysAware.php
@@ -2,6 +2,8 @@
 
 namespace Gaufrette\Adapter;
 
+use Gaufrette\Exception\StorageFailure;
+
 /**
  * interface that adds support of native listKeys to adapter.
  *
@@ -16,6 +18,8 @@ interface ListKeysAware
      * @param string $prefix
      *
      * @return array
+     *
+     * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function listKeys($prefix = '');
 }

--- a/src/Gaufrette/Adapter/MimeTypeProvider.php
+++ b/src/Gaufrette/Adapter/MimeTypeProvider.php
@@ -2,6 +2,8 @@
 
 namespace Gaufrette\Adapter;
 
+use Gaufrette\Exception\StorageFailure;
+
 /**
  * Interface which add mime type provider support to adapter.
  *
@@ -15,6 +17,8 @@ interface MimeTypeProvider
      * @param string $key
      *
      * @return string
+     *
+     * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function mimeType($key);
 }

--- a/src/Gaufrette/Adapter/MimeTypeProvider.php
+++ b/src/Gaufrette/Adapter/MimeTypeProvider.php
@@ -2,6 +2,7 @@
 
 namespace Gaufrette\Adapter;
 
+use Gaufrette\Exception\FileNotFound;
 use Gaufrette\Exception\StorageFailure;
 
 /**
@@ -18,6 +19,7 @@ interface MimeTypeProvider
      *
      * @return string
      *
+     * @throws FileNotFound
      * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function mimeType($key);

--- a/src/Gaufrette/Adapter/SizeCalculator.php
+++ b/src/Gaufrette/Adapter/SizeCalculator.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Gaufrette\Adapter;
+use Gaufrette\Exception\StorageFailure;
 
 /**
  * Interface which add size calculation support to adapter.
@@ -15,6 +16,8 @@ interface SizeCalculator
      * @param string $key
      *
      * @return int
+     *
+     * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function size($key);
 }

--- a/src/Gaufrette/Adapter/SizeCalculator.php
+++ b/src/Gaufrette/Adapter/SizeCalculator.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Gaufrette\Adapter;
+use Gaufrette\Exception\FileNotFound;
 use Gaufrette\Exception\StorageFailure;
 
 /**
@@ -17,6 +18,7 @@ interface SizeCalculator
      *
      * @return int
      *
+     * @throws FileNotFound
      * @throws StorageFailure If the underlying storage fails (adapter should not leak exceptions)
      */
     public function size($key);

--- a/src/Gaufrette/Exception/StorageFailure.php
+++ b/src/Gaufrette/Exception/StorageFailure.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Gaufrette\Exception;
+
+use Gaufrette\Exception;
+
+/**
+ * Exception thrown when an unexpected error happened at the storage level (or its underlying sdk).
+ *
+ * @author Albin Kerouanton <albin.kerouanton@knplabs.com>
+ */
+class StorageFailure extends \RuntimeException implements Exception
+{
+    /**
+     * Instantiate a new StorageFailure exception for a particular adapter action.
+     *
+     * @param string          $action    The adapter action (e.g read, write, listKeys, ...) that throw the exception.
+     * @param array           $args      Arguments used by the action (like the read key).
+     * @param \Exception|null $previous  Previous exception, if any was thrown (like exception from AWS sdk).
+     *
+     * @return StorageFailure
+     */
+    public static function unexpectedFailure($action, array $args, \Exception $previous = null)
+    {
+        $args = array_map(function ($k, $v) {
+            $v = is_string($v) ? '"'.$v.'"' : $v;
+
+            return "{$k}: {$v}";
+        }, array_keys($args), $args);
+
+        return new self(
+            sprintf('An unexpected error happened during %s (%s).', $action, implode(', ', $args)),
+            0,
+            $previous
+        );
+    }
+}

--- a/tests/Gaufrette/Functional/Adapter/AwsS3Test.php
+++ b/tests/Gaufrette/Functional/Adapter/AwsS3Test.php
@@ -8,6 +8,8 @@ use Gaufrette\Filesystem;
 
 class AwsS3Test extends FunctionalTestCase
 {
+    use FileNotFoundTests;
+
     /** @var int */
     static private $SDK_VERSION;
 

--- a/tests/Gaufrette/Functional/Adapter/FileNotFoundTests.php
+++ b/tests/Gaufrette/Functional/Adapter/FileNotFoundTests.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Gaufrette\Functional\Adapter;
+
+trait FileNotFoundTests
+{
+    /**
+     * @expectedException Gaufrette\Exception\FileNotFound
+     */
+    public function testAdapterShouldThrowAnExceptionIfTheFileReadDoesNotExist()
+    {
+        $this->filesystem->getAdapter()->read('does-not-exist');
+    }
+
+    /**
+     * @expectedException Gaufrette\Exception\FileNotFound
+     */
+    public function testAdapterShouldThrowAnExceptionIfTheFileRenamedDoesNotExist()
+    {
+        $this->filesystem->getAdapter()->rename('does-not-exist', 'foo');
+    }
+
+    /**
+     * @expectedException Gaufrette\Exception\FileNotFound
+     */
+    public function testAdapterShouldThrowAnExceptionIfTheFileDeletedDoesNotExist()
+    {
+        $this->filesystem->getAdapter()->delete('does-not-exist');
+    }
+
+    /**
+     * @expectedException Gaufrette\Exception\FileNotFound
+     */
+    public function testAdapterShouldThrowAnExceptionIfTheMtimeIsRetrievedForAnNonExistentFile()
+    {
+        $this->filesystem->getAdapter()->mtime('does-not-exist');
+    }
+
+    /**
+     * @expectedException Gaufrette\Exception\FileNotFound
+     */
+    public function testAdapterShouldThrowAnExceptionIfTheSizeIsRetrievedForAnNonExistentFile()
+    {
+        $this->filesystem->getAdapter()->size('does-not-exist');
+    }
+}


### PR DESCRIPTION
The main reason: it's currently impossible to know what's going wrong when one of the method fails. So rather than bad return values, I updated the Adapter API to throw exceptions.

So, this PR introduces two exceptions to be used by adapters: `Gaufrette\Exception\StorageFailure` and `Gaufrette\Exception\FileNotFound`. I implemented only AwsS3 for now and Filesystem methods would benefit from such overhauling (something like `FilesystemException`). But this patch has been done mostly to demonstrates what we could do to enhance the current API, more will come if this one is accepted.

See #497.