### PR TITLE
Enable mbstring ext on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,7 @@ install:
   - IF %PHP%==1 echo extension=php_pdo_sqlite.dll >> php.ini
   - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
   - IF %PHP%==1 echo extension=php_curl.dll >> php.ini
+  - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
   - IF %PHP%==1 echo openssl.cafile=c:\php\cacert.pem >> php.ini
   - cd C:\projects\gaufrette
   - appveyor DownloadFile https://getcomposer.org/composer.phar


### PR DESCRIPTION
Since latest commits from master have been merged in the 1.x branch,
AppVeyor now really runs the tests (see #512). But phpunit has been
upgraded from v3.7 to v5.7 only in the 1.x branch and it now requires
the mbstring extension to be installed.

EDIT: I don't know why but it looks like AppVeyor won't run tests for this PR :O Still, tests are green on AppVeyor (I enabled it for my fork), [see here](https://ci.appveyor.com/project/NiR-/gaufrette-1gwa5/build/1.0.273).