### PR TITLE
Added support for calculated size for Azure Blob Storage

### DIFF
--- a/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
+++ b/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
@@ -98,6 +98,19 @@ class AzureMultiContainerBlobStorageTest extends FunctionalTestCase
     /**
      * @test
      * @group functional
+     */
+    public function shouldGetSize()
+    {
+        $path = $this->createUniqueContainerName('container') . '/foo';
+
+        $this->filesystem->write($path, 'Some content');
+
+        $this->assertGreaterThan(11, $this->filesystem->size($path));
+    }
+
+    /**
+     * @test
+     * @group functional
      * @expectedException \RuntimeException
      * @expectedMessage Could not get mtime for the "foo" key
      */

--- a/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
+++ b/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
@@ -103,9 +103,9 @@ class AzureMultiContainerBlobStorageTest extends FunctionalTestCase
     {
         $path = $this->createUniqueContainerName('container') . '/foo';
 
-        $this->filesystem->write($path, 'Some content');
+        $contentSize = $this->filesystem->write($path, 'Some content');
 
-        $this->assertGreaterThan(11, $this->filesystem->size($path));
+        $this->assertEquals($contentSize, $this->filesystem->size($path));
     }
 
     /**


### PR DESCRIPTION
Added the SizeCalculator to the Azure Blob Storage. Size will be retrieved from the blob properties, instead of loading the complete file into memory in order to determine the filesize. 

Tested with a local environment.