### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Imagine you have to manage a lot of medias in a PHP project. Lets see how to
 take this situation in your advantage using Gaufrette.
 
 The filesystem abstraction layer permits you to develop your application without
-the need to know were all those medias will be stored and how.
+the need to know where all those medias will be stored and how.
 
 Another advantage of this is the possibility to update the files location
 without any impact on the code apart from the definition of your filesystem.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name":         "knplabs/gaufrette",
     "type":         "library",
-    "description":  "PHP5 library that provides a filesystem abstraction layer",
+    "description":  "PHP library that provides a filesystem abstraction layer",
     "keywords":     ["file", "filesystem", "media", "abstraction"],
     "homepage":     "http://knplabs.com",
     "license":      "MIT",


### PR DESCRIPTION
Fixed typo in the README and removed version constraint from the
composer description because it no longer holds.