### PR TITLE
Quickfix for Adapter/AwsS3, check if count() call is allowed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
   - docker run -d --name ftpd_server -p ${FTP_PORT}:21 -p 30000-30009:30000-30009 -e "PUBLICHOST=${FTP_HOST}" stilliard/pure-ftpd
   - docker exec -it ftpd_server sh -c "(echo ${FTP_PASSWORD}; echo ${FTP_PASSWORD}) | pure-pw useradd ${FTP_USER} -f /etc/pure-ftpd/passwd/pureftpd.passwd -m -u ftpuser -d /home/ftpusers/${FTP_USER}"
   - if [[ ${TRAVIS_PHP_VERSION} = 5.* ]]; then sudo apt-get -qq update && sudo apt-get install -y libssh2-1-dev; fi
-  - if [[ ${TRAVIS_PHP_VERSION} = 5.* ]]; then yes | pecl install ssh2 && composer require herzult/php-ssh --no-update --no-scripts; fi
+  - if [[ ${TRAVIS_PHP_VERSION} = 5.* ]]; then yes | pecl install -f ssh2 && composer require herzult/php-ssh --no-update --no-scripts; fi
 
 install:
   - composer update --prefer-dist --no-progress --no-suggest --ansi

--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -270,8 +270,13 @@ class AwsS3 implements Adapter,
             'Prefix' => rtrim($this->computePath($key), '/').'/',
             'MaxKeys' => 1,
         ]);
+        if (isset($result['Contents'])) {
+            if (is_array($result['Contents']) || $result['Contents'] instanceof \Countable) {
+                return count($result['Contents']) > 0;
+            }
+        }
 
-        return count($result['Contents']) > 0;
+        return false;
     }
 
     /**


### PR DESCRIPTION
(cherry picked from commit ad3aad3)
Quickfix for issue #539 

In my case, there was no key `Content` in the `$result`-object. So I check.