### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
+++ b/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
@@ -206,7 +206,7 @@ class AzureMultiContainerBlobStorageTest extends FunctionalTestCase
         $FileObjectA = $this->filesystem->createFile($path);
         $FileObjectB = $this->filesystem->createFile($path);
 
-        $this->assertTrue($FileObjectA === $FileObjectB);
+        $this->assertSame($FileObjectB, $FileObjectA);
     }
 
     /**

--- a/tests/Gaufrette/Functional/Adapter/LocalTest.php
+++ b/tests/Gaufrette/Functional/Adapter/LocalTest.php
@@ -160,7 +160,7 @@ class LocalTest extends FunctionalTestCase
         $this->filesystem->clearFileRegister();
         $fsRegister = $fsReflection->getProperty('fileRegister');
         $fsRegister->setAccessible(true);
-        $this->assertEquals(0, count($fsRegister->getValue($this->filesystem)));
+        $this->assertCount(0, $fsRegister->getValue($this->filesystem));
 
         $this->filesystem->delete('test.txt');
         $this->filesystem->delete('test2.txt');

--- a/tests/Gaufrette/Functional/FileStream/FunctionalTestCase.php
+++ b/tests/Gaufrette/Functional/FileStream/FunctionalTestCase.php
@@ -26,10 +26,10 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
     public function shouldCheckFileExists()
     {
         $this->filesystem->write('test.txt', 'some content');
-        $this->assertTrue(file_exists('gaufrette://filestream/test.txt'));
+        $this->assertFileExists('gaufrette://filestream/test.txt');
 
         $this->filesystem->delete('test.txt');
-        $this->assertFalse(file_exists('gaufrette://filestream/test.txt'));
+        $this->assertFileNotExists('gaufrette://filestream/test.txt');
     }
 
     /**
@@ -201,7 +201,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
     public function shouldCreateNewFile($mode)
     {
         $fileHandler = fopen('gaufrette://filestream/test.txt', $mode);
-        $this->assertTrue(file_exists('gaufrette://filestream/test.txt'));
+        $this->assertFileExists('gaufrette://filestream/test.txt');
     }
 
     public static function modesProvider()

--- a/tests/Gaufrette/Functional/FileStream/LocalTest.php
+++ b/tests/Gaufrette/Functional/FileStream/LocalTest.php
@@ -44,6 +44,6 @@ class LocalTest extends FunctionalTestCase
     public function shouldSupportsDirectory()
     {
         $this->assertFileExists('gaufrette://filestream/subdir');
-        $this->assertTrue(is_dir('gaufrette://filestream/subdir'));
+        $this->assertDirectoryExists('gaufrette://filestream/subdir');
     }
 }


### PR DESCRIPTION
I've used some `PHPUnit` assertion method on top of `PHP`'s function while testing, so we can get better error messages in case of failure :smile: 

Thanks to [`Rector`](https://github.com/rectorphp/rector) that helped me find them.