### PR TITLE
fix travis build for php 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
   - docker run -d --name ftpd_server -p ${FTP_PORT}:21 -p 30000-30009:30000-30009 -e "PUBLICHOST=${FTP_HOST}" stilliard/pure-ftpd
   - docker exec -it ftpd_server sh -c "(echo ${FTP_PASSWORD}; echo ${FTP_PASSWORD}) | pure-pw useradd ${FTP_USER} -f /etc/pure-ftpd/passwd/pureftpd.passwd -m -u ftpuser -d /home/ftpusers/${FTP_USER}"
   - if [[ ${TRAVIS_PHP_VERSION} = 5.* ]]; then sudo apt-get -qq update && sudo apt-get install -y libssh2-1-dev; fi
-  - if [[ ${TRAVIS_PHP_VERSION} = 5.* ]]; then yes | pecl install ssh2 && composer require herzult/php-ssh --no-update --no-scripts; fi
+  - if [[ ${TRAVIS_PHP_VERSION} = 5.* ]]; then yes | pecl install -f ssh2 && composer require herzult/php-ssh --no-update --no-scripts; fi
 
 install:
   - composer update --prefer-dist --no-progress --no-suggest --ansi


### PR DESCRIPTION
See https://travis-ci.org/KnpLabs/Gaufrette/jobs/324904975 : 
```
$ if [[ ${TRAVIS_PHP_VERSION} = 5.* ]]; then yes | pecl install ssh2 && composer require herzult/php-ssh --no-update --no-scripts; fi
pecl/ssh2 is already installed and is the same as the released version 0.13
install failed
```