### PR TITLE
Fix a race condition in AzureBlobStorage::keys() when used in multi container mode

### DIFF
--- a/src/Gaufrette/Exception/StorageFailure.php
+++ b/src/Gaufrette/Exception/StorageFailure.php
@@ -23,7 +23,7 @@ class StorageFailure extends \RuntimeException implements Exception
     public static function unexpectedFailure($action, array $args, \Exception $previous = null)
     {
         $args = array_map(function ($k, $v) {
-            $v = is_string($v) ? '"'.$v.'"' : $v;
+            $v = var_export($v, true);
 
             return "{$k}: {$v}";
         }, array_keys($args), $args);


### PR DESCRIPTION
That should fix Travis builds :)

This race condition ocurrs when the adapter is used in multi container mode. When keys() is called,
containers are listed and iterated, but if one of them is deleted before its content is listed,
then the adapter throws an exception when iterating over it.