### PR TITLE
Fix flaky tests failing when run in parallel

### DIFF
--- a/tests/Gaufrette/Functional/Adapter/DoctrineDbalTest.php
+++ b/tests/Gaufrette/Functional/Adapter/DoctrineDbalTest.php
@@ -8,7 +8,7 @@ use Gaufrette\Filesystem;
 
 class DoctrineDbalTest extends FunctionalTestCase
 {
-    /** @var  \Doctrine\DBAL\Connection */
+    /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
     public function setUp()

--- a/tests/Gaufrette/Functional/Adapter/FtpTest.php
+++ b/tests/Gaufrette/Functional/Adapter/FtpTest.php
@@ -7,6 +7,9 @@ use Gaufrette\Filesystem;
 
 class FtpTest extends FunctionalTestCase
 {
+    /** @var string */
+    private $basePath;
+
     public function setUp()
     {
         $host     = getenv('FTP_HOST');
@@ -19,7 +22,15 @@ class FtpTest extends FunctionalTestCase
             $this->markTestSkipped('Either FTP_HOST, FTP_USER, FTP_PASSWORD and/or FTP_BASE_DIR env variables are not defined.');
         }
 
-        $adapter = new Ftp($baseDir, $host, ['port' => $port, 'username' => $user, 'password' => $password, 'passive' => true, 'create' => true]);
+        $baseDir = rtrim($baseDir, '/') . DIRECTORY_SEPARATOR . uniqid();
+
+        $adapter = new Ftp($baseDir, $host, [
+            'port'     => $port,
+            'username' => $user,
+            'password' => $password,
+            'passive'  => true,
+            'create'   => true
+        ]);
         $this->filesystem = new Filesystem($adapter);
     }
 

--- a/tests/Gaufrette/Functional/Adapter/LocalTest.php
+++ b/tests/Gaufrette/Functional/Adapter/LocalTest.php
@@ -12,7 +12,7 @@ class LocalTest extends FunctionalTestCase
 
     public function setUp()
     {
-        $this->directory = sprintf('%s/filesystem', str_replace('\\', '/', __DIR__));
+        $this->directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('gaufrette-tests');
 
         if (!file_exists($this->directory)) {
             mkdir($this->directory);

--- a/tests/Gaufrette/Functional/Adapter/ZipTest.php
+++ b/tests/Gaufrette/Functional/Adapter/ZipTest.php
@@ -10,14 +10,15 @@ class ZipTest extends FunctionalTestCase
     public function setUp()
     {
         if (!extension_loaded('zip')) {
-            return $this->markTestSkipped('The zip extension is not available.');
+            $this->markTestSkipped('The zip extension is not available.');
         } elseif (strtolower(substr(PHP_OS, 0, 3)) === 'win') {
             $this->markTestSkipped('Zip adapter is not supported on Windows.');
         }
 
-        @touch(__DIR__ . '/test.zip');
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('gaufrette-test');
+        @touch($path);
 
-        $this->filesystem = new Filesystem(new Zip(__DIR__ . '/test.zip'));
+        $this->filesystem = new Filesystem(new Zip($path));
     }
 
     public function tearDown()

--- a/tests/Gaufrette/Functional/FileStream/LocalTest.php
+++ b/tests/Gaufrette/Functional/FileStream/LocalTest.php
@@ -12,7 +12,8 @@ class LocalTest extends FunctionalTestCase
 
     public function setUp()
     {
-        $this->directory = __DIR__.DIRECTORY_SEPARATOR.'filesystem';
+        $this->directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('gaufrette-tests');
+
         @mkdir($this->directory.DIRECTORY_SEPARATOR.'subdir', 0777, true);
         umask(0002);
         $this->filesystem = new Filesystem(new LocalAdapter($this->directory, true, 0770));


### PR DESCRIPTION
Tests for Ftp, GridFS, Zip and Local adapters are failing when run in parallel, for example when they are run locally with multiple php versions. This is due to hardcoded base path, database name, ...  so this fix randomize them.
  