### PR TITLE
[1.x] bump phpunit to v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpseclib/phpseclib": "^2.0",
         "doctrine/dbal": ">=2.3",
         "dropbox-php/dropbox-php": "*",
-        "phpunit/phpunit": "~5.7",
+        "phpunit/phpunit": "~6.5",
         "mikey179/vfsStream": "~1.2.0",
         "league/flysystem": "~1.0",
         "mongodb/mongodb": "^1.1",

--- a/tests/Gaufrette/Functional/FileStream/FunctionalTestCase.php
+++ b/tests/Gaufrette/Functional/FileStream/FunctionalTestCase.php
@@ -3,8 +3,9 @@
 namespace Gaufrette\Functional\FileStream;
 
 use Gaufrette\StreamWrapper;
+use PHPUnit\Framework\TestCase;
 
-class FunctionalTestCase extends \PHPUnit_Framework_TestCase
+class FunctionalTestCase extends TestCase
 {
     protected $filesystem;
 


### PR DESCRIPTION
As it [requires at least PHP 7.0](https://phpunit.de/). Related to #552 .