### PR TITLE
[1.x] bump phpspec to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "amazonwebservices/aws-sdk-for-php": "1.5.*",
         "rackspace/php-opencloud"  : "^1.9.2",
         "google/apiclient": "~1.1.3",
-        "phpspec/phpspec": "^3.0",
+        "phpspec/phpspec": "~4.3",
         "phpseclib/phpseclib": "^2.0",
         "doctrine/dbal": ">=2.3",
         "dropbox-php/dropbox-php": "*",
@@ -36,7 +36,7 @@
         "mongodb/mongodb": "^1.1",
         "microsoft/windowsazure": "~0.4",
         "microsoft/azure-storage": "~0.15.0",
-        "akeneo/phpspec-skip-example-extension": "2.0.*"
+        "akeneo/phpspec-skip-example-extension": "^3.0"
     },
     "suggest": {
         "knplabs/knp-gaufrette-bundle": "to use with Symfony",


### PR DESCRIPTION
As it [requires at least PHP 7.0](https://packagist.org/packages/phpspec/phpspec). Related to #552 .