### PR TITLE
Add support for major release of Azure Blob Storage SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
         "mikey179/vfsStream": "~1.2.0",
         "league/flysystem": "~1.0",
         "mongodb/mongodb": "^1.1",
-        "microsoft/windowsazure": "~0.4",
-        "microsoft/azure-storage": "~0.15.0",
+        "microsoft/azure-storage-blob": "^1.0",
         "akeneo/phpspec-skip-example-extension": "~1.2"
     },
     "suggest": {

--- a/doc/adapters/azure-blob-storage.md
+++ b/doc/adapters/azure-blob-storage.md
@@ -4,14 +4,10 @@ currentMenu: azure-blob-storage
 
 # AzureBlobStorage
 
-First, you will need to install the adapter:
+Azure Blob Storage is the storage service provided by Microsoft Windows Azure cloud environment. First, you will need to install the adapter:
 ```bash
 composer require gaufrette/azure-blob-storage-adapter
 ```
-
-Azure Blob Storage is the storage service provided by Microsoft Windows Azure cloud environment. To use this adapter
-you need to install the [Azure SDK for php](http://www.windowsazure.com/en-us/develop/php/common-tasks/download-php-sdk/)
-into your project.
 
 To instantiate the `AzureBlobStorage` adapter you need a `BlobProxyFactoryInterface` instance (you can use the default
 `BlobProxyFactory` class) and a connection string. The connection string should follow this prototype:

--- a/src/Gaufrette/Adapter/AzureBlobStorage.php
+++ b/src/Gaufrette/Adapter/AzureBlobStorage.php
@@ -8,6 +8,7 @@ use Gaufrette\Adapter\AzureBlobStorage\BlobProxyFactoryInterface;
 use MicrosoftAzure\Storage\Blob\Models\Blob;
 use MicrosoftAzure\Storage\Blob\Models\Container;
 use MicrosoftAzure\Storage\Blob\Models\CreateBlobOptions;
+use MicrosoftAzure\Storage\Blob\Models\CreateBlockBlobOptions;
 use MicrosoftAzure\Storage\Blob\Models\CreateContainerOptions;
 use MicrosoftAzure\Storage\Blob\Models\DeleteContainerOptions;
 use MicrosoftAzure\Storage\Blob\Models\ListBlobsOptions;
@@ -187,7 +188,12 @@ class AzureBlobStorage implements Adapter,
         $this->init();
         list($containerName, $key) = $this->tokenizeKey($key);
 
-        $options = new CreateBlobOptions();
+        if (class_exists(CreateBlockBlobOptions::class)) {
+            $options = new CreateBlockBlobOptions();
+        } else {
+            // for microsoft/azure-storage < 1.0
+            $options = new CreateBlobOptions();
+        }
 
         if ($this->detectContentType) {
             $contentType = $this->guessContentType($content);

--- a/src/Gaufrette/Adapter/AzureBlobStorage/BlobProxyFactory.php
+++ b/src/Gaufrette/Adapter/AzureBlobStorage/BlobProxyFactory.php
@@ -2,6 +2,7 @@
 
 namespace Gaufrette\Adapter\AzureBlobStorage;
 
+use MicrosoftAzure\Storage\Blob\BlobRestProxy;
 use MicrosoftAzure\Storage\Common\ServicesBuilder;
 
 /**
@@ -29,6 +30,11 @@ class BlobProxyFactory implements BlobProxyFactoryInterface
      */
     public function create()
     {
-        return ServicesBuilder::getInstance()->createBlobService($this->connectionString);
+        if (class_exists(ServicesBuilder::class)) {
+            // for microsoft/azure-storage < 1.0
+            return ServicesBuilder::getInstance()->createBlobService($this->connectionString);
+        } else {
+            return BlobRestProxy::createBlobService($this->connectionString);
+        }
     }
 }

--- a/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
+++ b/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
@@ -213,7 +213,7 @@ class AzureMultiContainerBlobStorageTest extends FunctionalTestCase
      * @test
      * @group functional
      */
-    public function shouldWrtieToSameFile()
+    public function shouldWriteToSameFile()
     {
         $path = $this->createUniqueContainerName('container') . '/somefile';
 
@@ -223,7 +223,7 @@ class AzureMultiContainerBlobStorageTest extends FunctionalTestCase
         $FileObjectB = $this->filesystem->createFile($path);
         $FileObjectB->setContent('DEF');
 
-        $this->assertEquals('DEF', $FileObjectB->getContent());
+        $this->assertEquals('DEF', $FileObjectA->getContent());
     }
 
     private function createUniqueContainerName($prefix)

--- a/tests/Gaufrette/Functional/Adapter/FunctionalTestCase.php
+++ b/tests/Gaufrette/Functional/Adapter/FunctionalTestCase.php
@@ -211,6 +211,6 @@ EOF
         $FileObjectB = $this->filesystem->createFile('somefile');
         $FileObjectB->setContent('DEF');
 
-        $this->assertEquals('DEF', $FileObjectB->getContent());
+        $this->assertEquals('DEF', $FileObjectA->getContent());
     }
 }


### PR DESCRIPTION
The SDK for Azure Storage [was recently split up](https://github.com/Azure/azure-storage-php/issues/111) in 4 separate packages. Now, it's recommended to use `microsoft/azure-storage-blob` for handling blobs.

This patch extends the adapter to support the new SDK as well (in a backwards-compatible way). The functional tests pass with both versions.