### PR TITLE
drop azure storage BC

### DIFF
--- a/src/Gaufrette/Adapter/AzureBlobStorage.php
+++ b/src/Gaufrette/Adapter/AzureBlobStorage.php
@@ -8,7 +8,6 @@ use Gaufrette\Exception\InvalidKey;
 use Gaufrette\Exception\StorageFailure;
 use Gaufrette\Adapter\AzureBlobStorage\BlobProxyFactoryInterface;
 use MicrosoftAzure\Storage\Blob\Models\Blob;
-use MicrosoftAzure\Storage\Blob\Models\CreateBlobOptions;
 use MicrosoftAzure\Storage\Blob\Models\CreateBlockBlobOptions;
 use MicrosoftAzure\Storage\Blob\Models\CreateContainerOptions;
 use MicrosoftAzure\Storage\Common\Exceptions\ServiceException;
@@ -182,12 +181,7 @@ class AzureBlobStorage implements Adapter,
         $this->init();
         list($containerName, $key) = $this->tokenizeKey($key);
 
-        if (class_exists(CreateBlockBlobOptions::class)) {
-            $options = new CreateBlockBlobOptions();
-        } else {
-            // for microsoft/azure-storage < 1.0
-            $options = new CreateBlobOptions();
-        }
+        $options = new CreateBlockBlobOptions();
 
         if ($this->detectContentType) {
             $contentType = $this->guessContentType($content);

--- a/src/Gaufrette/Adapter/AzureBlobStorage/BlobProxyFactory.php
+++ b/src/Gaufrette/Adapter/AzureBlobStorage/BlobProxyFactory.php
@@ -3,7 +3,6 @@
 namespace Gaufrette\Adapter\AzureBlobStorage;
 
 use MicrosoftAzure\Storage\Blob\BlobRestProxy;
-use MicrosoftAzure\Storage\Common\ServicesBuilder;
 
 /**
  * Basic implementation for a Blob proxy factory.
@@ -30,11 +29,6 @@ class BlobProxyFactory implements BlobProxyFactoryInterface
      */
     public function create()
     {
-        if (class_exists(ServicesBuilder::class)) {
-            // for microsoft/azure-storage < 1.0
-            return ServicesBuilder::getInstance()->createBlobService($this->connectionString);
-        } else {
-            return BlobRestProxy::createBlobService($this->connectionString);
-        }
+        return BlobRestProxy::createBlobService($this->connectionString);
     }
 }


### PR DESCRIPTION
Related to #554 .

Drop azure storage BC and only use azure blob storage v1 SDK (introduced by #558 ).