### PR TITLE
Add PutObjectAcl in the required permission

### DIFF
--- a/doc/adapters/aws-s3.md
+++ b/doc/adapters/aws-s3.md
@@ -74,6 +74,7 @@ for production environment.
             "Effect": "Allow",
             "Action": [
                 "s3:PutObject",
+                "s3:PutObjectAcl",
                 "s3:GetObject",
                 "s3:DeleteObject"
             ],


### PR DESCRIPTION
Without this permission, the application can't create a media in the bucket.