### PR TITLE
Fix ini_get() for boolean values

### DIFF
--- a/tests/Gaufrette/Functional/Adapter/ApcTest.php
+++ b/tests/Gaufrette/Functional/Adapter/ApcTest.php
@@ -11,7 +11,7 @@ class ApcTest extends FunctionalTestCase
     {
         if (!extension_loaded('apc')) {
             return $this->markTestSkipped('The APC extension is not available.');
-        } elseif (!ini_get('apc.enabled') || !ini_get('apc.enable_cli')) {
+        } elseif (!filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) || !filter_var(ini_get('apc.enable_cli'), FILTER_VALIDATE_BOOLEAN)) {
             return $this->markTestSkipped('The APC extension is available, but not enabled.');
         }
 


### PR DESCRIPTION
Currently setting false or off, ... value to configure some PHP ini directives will make this evaluated to true as this is equal to a non empty string.