### PR TITLE
fix php7.3 warning about continue in switch

### DIFF
--- a/src/Gaufrette/Util/Path.php
+++ b/src/Gaufrette/Util/Path.php
@@ -27,13 +27,13 @@ class Path
         foreach ($parts as $part) {
             switch ($part) {
                 case '.':
-                    continue;
+                    break;
                 case '..':
                     if (0 !== count($tokens)) {
                         array_pop($tokens);
-                        continue;
+                        break;
                     } elseif (!empty($prefix)) {
-                        continue;
+                        break;
                     }
                 default:
                     $tokens[] = $part;


### PR DESCRIPTION
In Path.php line 31:

  [Symfony\Component\Debug\Exception\ContextErrorException]
  Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?
