### PR TITLE
Implement ChecksumCalculator Interface

### DIFF
--- a/src/Gaufrette/Adapter/AzureBlobStorage.php
+++ b/src/Gaufrette/Adapter/AzureBlobStorage.php
@@ -22,7 +22,8 @@ use MicrosoftAzure\Storage\Common\Exceptions\ServiceException;
  */
 class AzureBlobStorage implements Adapter,
                                   MetadataSupporter,
-                                  SizeCalculator
+                                  SizeCalculator,
+                                  ChecksumCalculator
 
 {
     /**
@@ -332,6 +333,26 @@ class AzureBlobStorage implements Adapter,
             return false;
         }
 
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checksum($key)
+    {
+        $this->init();
+        list($containerName, $key) = $this->tokenizeKey($key);
+
+        try {
+            $properties = $this->blobProxy->getBlobProperties($containerName, $key);
+            $checksumBase64 = $properties->getProperties()->getContentMD5();
+
+            return \bin2hex(\base64_decode($checksumBase64, true));
+        } catch (ServiceException $e) {
+            $this->failIfContainerNotFound($e, sprintf('read content MD5 for key "%s"', $key), $containerName);
+
+            return false;
+        }
     }
 
     /**

--- a/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
+++ b/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
@@ -111,6 +111,20 @@ class AzureMultiContainerBlobStorageTest extends FunctionalTestCase
     /**
      * @test
      * @group functional
+     */
+    public function shouldGetMd5Hash()
+    {
+        $path = $this->createUniqueContainerName('container') . '/foo';
+
+        $content = 'Some content';
+        $this->filesystem->write($path, $content);
+
+        $this->assertEquals(\md5($content), $this->filesystem->checksum($path));
+    }
+
+    /**
+     * @test
+     * @group functional
      * @expectedException \RuntimeException
      * @expectedMessage Could not get mtime for the "foo" key
      */


### PR DESCRIPTION
If an application is handling videos, the method to download the file locally and calculate the MD5 hash is not feasible. Azure calculates the MD5 hash, this PR implements fetching MD5 info from Azure.