### PR TITLE
Fixing GridFS metadata bug where no metadata array returned

### DIFF
--- a/src/Gaufrette/Adapter/GridFS.php
+++ b/src/Gaufrette/Adapter/GridFS.php
@@ -170,7 +170,7 @@ class GridFS implements Adapter,
             return $this->metadata[$key];
         } else {
             $meta = $this->bucket->findOne(['filename' => $key], ['projection' => ['metadata' => 1,'_id' => 0]]);
-            if ($meta === null) {
+            if ($meta === null || !isset($meta['metadata'])) {
                 return array();
             }
             $this->metadata[$key] = iterator_to_array($meta['metadata']);

--- a/tests/Gaufrette/Functional/Adapter/GridFSTest.php
+++ b/tests/Gaufrette/Functional/Adapter/GridFSTest.php
@@ -8,6 +8,9 @@ use MongoDB\Client;
 
 class GridFSTest extends FunctionalTestCase
 {
+    
+    private $bucket;
+
     public function setUp()
     {
         $uri = getenv('MONGO_URI');
@@ -21,8 +24,8 @@ class GridFSTest extends FunctionalTestCase
         $db = $client->selectDatabase($dbname);
         $bucket = $db->selectGridFSBucket();
         $bucket->drop();
-
-        $this->filesystem = new Filesystem(new GridFS($bucket));
+        $this->bucket = $bucket;
+        $this->filesystem = new Filesystem(new GridFS($this->bucket));
     }
 
     /**
@@ -88,5 +91,13 @@ class GridFSTest extends FunctionalTestCase
         $this->filesystem->write('metadatatest', 'test');
         
         $this->assertEquals($this->filesystem->getAdapter()->getMetadata('metadatatest'), $fileadpt->getMetadata('metadatatest'));
+    }
+
+    public function testRetrieveWithoutMetadata()
+    {
+        $resource = $this->bucket->openUploadStream("test1.test");
+        fwrite($resource, "test");
+        fclose($resource);
+        $this->assertEquals($this->filesystem->getAdapter()->getMetadata('test1.test'), array());
     }
 }


### PR DESCRIPTION
Fixing a gridfs adapter bug where the object exists but it does not contain a metadata array.