### PR TITLE
Change Filesystem to FilesystemInterface in File

### DIFF
--- a/src/Gaufrette/File.php
+++ b/src/Gaufrette/File.php
@@ -50,9 +50,9 @@ class File
 
     /**
      * @param string     $key
-     * @param Filesystem $filesystem
+     * @param FilesystemInterface $filesystem
      */
-    public function __construct($key, Filesystem $filesystem)
+    public function __construct($key, FilesystemInterface $filesystem)
     {
         $this->key = $key;
         $this->name = $key;


### PR DESCRIPTION
To extend functionality of Gaufrette to support [`ResolvableFilesystem`](https://github.com/Gaufrette/extras/blob/master/src/Resolvable/ResolvableFilesystem.php), signature change is proposed to `FilesystemInterface`.

In some implementations there's File already provided and it could be resolved by filesystem. Now its not possible to use one filesystem to store files and resolve files because of aforementioned signature.