### PR TITLE
[GridFS] Fix : return empty array when object has no metadata

### DIFF
--- a/src/Gaufrette/Adapter/GridFS.php
+++ b/src/Gaufrette/Adapter/GridFS.php
@@ -171,10 +171,13 @@ class GridFS implements Adapter,
             return $this->metadata[$key];
         } else {
             $meta = $this->bucket->findOne(['filename' => $key], ['projection' => ['metadata' => 1,'_id' => 0]]);
-            if ($meta === null) {
+
+            if ($meta === null || !isset($meta['metadata'])) {
                 return array();
             }
+
             $this->metadata[$key] = iterator_to_array($meta['metadata']);
+
             return $this->metadata[$key];
         }
     }
@@ -206,7 +209,7 @@ class GridFS implements Adapter,
 
         return $result;
     }
-    
+
     public function size($key)
     {
         if (!$this->exists($key)) {
@@ -219,5 +222,5 @@ class GridFS implements Adapter,
 
         return $size['length'];
     }
-    
+
 }

--- a/tests/Gaufrette/Functional/Adapter/GridFSTest.php
+++ b/tests/Gaufrette/Functional/Adapter/GridFSTest.php
@@ -74,7 +74,7 @@ class GridFSTest extends FunctionalTestCase
             $keys['keys'],
             '', 0, 10, true);
     }
-    
+
     /**
      * @test
      * Tests metadata written to GridFS can be retrieved after writing
@@ -83,10 +83,10 @@ class GridFSTest extends FunctionalTestCase
     {
         //Create local copy of fileadapter
         $fileadpt = clone $this->filesystem->getAdapter();
-        
+
         $this->filesystem->getAdapter()->setMetadata('metadatatest', array('testing'  =>  true));
         $this->filesystem->write('metadatatest', 'test');
-        
+
         $this->assertEquals($this->filesystem->getAdapter()->getMetadata('metadatatest'), $fileadpt->getMetadata('metadatatest'));
     }
 
@@ -98,5 +98,16 @@ class GridFSTest extends FunctionalTestCase
     {
         $this->filesystem->write('sizetest.txt', 'data');
         $this->assertEquals(4, $this->filesystem->size('sizetest.txt'));
+    }
+
+    /**
+     * @test
+     * Should retrieve empty metadata w/o errors
+     */
+    public function testRetrieveWithoutMetadata()
+    {
+        $this->filesystem->write('no-metadata.txt', 'content');
+
+        $this->assertEquals(array(), $this->filesystem->getAdapter()->getMetadata('no-metadata.txt'));
     }
 }


### PR DESCRIPTION
Replaces #602 (and resolves conflicts).

Credits @bsperduto 