### PR TITLE
[1.0] Do not automatically create the base directory for Local adapter

### DIFF
--- a/spec/Gaufrette/Adapter/LocalSpec.php
+++ b/spec/Gaufrette/Adapter/LocalSpec.php
@@ -33,6 +33,13 @@ class LocalSpec extends ObjectBehavior
         $this->shouldHaveType('Gaufrette\Adapter\MimeTypeProvider');
     }
 
+    function it_throws_when_the_base_directory_does_not_exist()
+    {
+        $this->beConstructedWith('/do-no-exists');
+
+        $this->shouldThrow(StorageFailure::class)->duringInstantiation();
+    }
+
     function it_gets_the_file_mime_type()
     {
         $this->mimeType('filename')->shouldReturn('text/plain');

--- a/src/Gaufrette/Adapter/Local.php
+++ b/src/Gaufrette/Adapter/Local.php
@@ -23,7 +23,6 @@ class Local implements Adapter,
     MimeTypeProvider
 {
     protected $directory;
-    private $create;
     private $mode;
 
     /**
@@ -38,6 +37,12 @@ class Local implements Adapter,
 
         if (is_link($this->directory)) {
             $this->directory = realpath($this->directory);
+        }
+
+        if (!is_dir($this->directory)) {
+            throw new StorageFailure(
+                sprintf('Directory "%s" does not exist.', $directory)
+            );
         }
     }
 


### PR DESCRIPTION
Related to https://github.com/KnpLabs/Gaufrette/issues/618

We throw an exception when building the adapter if the specified base
directory does not exist. The write methods can still create sub
directories (eg /base/my/very/deep/dir), however the /base directory
have to be present.

The developer should create this directory on its own before using the
adapter.