### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/dbal": ">=2.3",
         "dropbox-php/dropbox-php": "*",
         "phpunit/phpunit": "~7.5",
-        "mikey179/vfsStream": "~1.2.0",
+        "mikey179/vfsstream": "~1.2.0",
         "league/flysystem": "~1.0",
         "mongodb/mongodb": "^1.1",
         "microsoft/azure-storage-blob": "^1.0",

--- a/tests/Gaufrette/Functional/Adapter/ApcTest.php
+++ b/tests/Gaufrette/Functional/Adapter/ApcTest.php
@@ -7,7 +7,7 @@ use Gaufrette\Filesystem;
 
 class ApcTest extends FunctionalTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         if (!extension_loaded('apc')) {
             return $this->markTestSkipped('The APC extension is not available.');
@@ -20,7 +20,7 @@ class ApcTest extends FunctionalTestCase
         $this->filesystem = new Filesystem(new Apc('gaufrette-test.'));
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         if (extension_loaded('apc')) {

--- a/tests/Gaufrette/Functional/Adapter/AwsS3Test.php
+++ b/tests/Gaufrette/Functional/Adapter/AwsS3Test.php
@@ -17,7 +17,7 @@ class AwsS3Test extends FunctionalTestCase
     /** @var S3Client */
     private $client;
 
-    public function setUp()
+    protected function setUp()
     {
         $key = getenv('AWS_KEY');
         $secret = getenv('AWS_SECRET');
@@ -54,7 +54,7 @@ class AwsS3Test extends FunctionalTestCase
         $this->createFilesystem(['create' => true]);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         if ($this->client === null || !$this->client->doesBucketExist($this->bucket)) {
             return;
@@ -81,31 +81,44 @@ class AwsS3Test extends FunctionalTestCase
     }
 
     /**
+     * @test
      * @expectedException \RuntimeException
      */
-    public function testThrowsExceptionIfBucketMissingAndNotCreating()
+    public function shouldThrowExceptionIfBucketMissingAndNotCreating()
     {
         $this->createFilesystem();
         $this->filesystem->read('foo');
     }
 
-    public function testWritesObjects()
+    /**
+     * @test
+     */
+    public function shouldWriteObjects()
     {
         $this->assertEquals(7, $this->filesystem->write('foo', 'testing'));
     }
 
-    public function testChecksForObjectExistence()
+    /**
+     * @test
+     */
+    public function shouldCheckForObjectExistence()
     {
         $this->filesystem->write('foo', '');
         $this->assertTrue($this->filesystem->has('foo'));
     }
 
-    public function testGetsObjectUrls()
+    /**
+     * @test
+     */
+    public function shouldGetObjectUrls()
     {
         $this->assertNotEmpty($this->filesystem->getAdapter()->getUrl('foo'));
     }
 
-    public function testChecksForObjectExistenceWithDirectory()
+    /**
+     * @test
+     */
+    public function shouldCheckForObjectExistenceWithDirectory()
     {
         $this->createFilesystem(['directory' => 'bar', 'create' => true]);
         $this->filesystem->write('foo', '');
@@ -113,20 +126,29 @@ class AwsS3Test extends FunctionalTestCase
         $this->assertTrue($this->filesystem->has('foo'));
     }
 
-    public function testGetsObjectUrlsWithDirectory()
+    /**
+     * @test
+     */
+    public function shouldGetObjectUrlsWithDirectory()
     {
         $this->createFilesystem(['directory' => 'bar']);
         $this->assertNotEmpty($this->filesystem->getAdapter()->getUrl('foo'));
     }
 
-    public function testListKeysWithoutDirectory()
+    /**
+     * @test
+     */
+    public function shouldListKeysWithoutDirectory()
     {
         $this->assertEquals([], $this->filesystem->listKeys());
         $this->filesystem->write('test.txt', 'some content');
         $this->assertEquals(['test.txt'], $this->filesystem->listKeys());
     }
 
-    public function testListKeysWithDirectory()
+    /**
+     * @test
+     */
+    public function shouldListKeysWithDirectory()
     {
         $this->createFilesystem(['create' => true, 'directory' => 'root/']);
         $this->filesystem->write('test.txt', 'some content');
@@ -134,20 +156,29 @@ class AwsS3Test extends FunctionalTestCase
         $this->assertTrue($this->filesystem->has('test.txt'));
     }
 
-    public function testKeysWithoutDirectory()
+    /**
+     * @test
+     */
+    public function shouldGetKeysWithoutDirectory()
     {
         $this->filesystem->write('test.txt', 'some content');
         $this->assertEquals(['test.txt'], $this->filesystem->keys());
     }
 
-    public function testKeysWithDirectory()
+    /**
+     * @test
+     */
+    public function shouldGetKeysWithDirectory()
     {
         $this->createFilesystem(['create' => true, 'directory' => 'root/']);
         $this->filesystem->write('test.txt', 'some content');
         $this->assertEquals(['test.txt'], $this->filesystem->keys());
     }
 
-    public function testUploadWithGivenContentType()
+    /**
+     * @test
+     */
+    public function shouldUploadWithGivenContentType()
     {
         /** @var AwsS3 $adapter */
         $adapter = $this->filesystem->getAdapter();

--- a/tests/Gaufrette/Functional/Adapter/AzureBlobStorageTest.php
+++ b/tests/Gaufrette/Functional/Adapter/AzureBlobStorageTest.php
@@ -18,7 +18,7 @@ class AzureBlobStorageTest extends FunctionalTestCase
     /** @var AzureBlobStorage */
     private $adapter;
 
-    public function setUp()
+    protected function setUp()
     {
         $account = getenv('AZURE_ACCOUNT');
         $key = getenv('AZURE_KEY');
@@ -35,7 +35,7 @@ class AzureBlobStorageTest extends FunctionalTestCase
         $this->filesystem = new Filesystem($this->adapter);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         if ($this->adapter === null) {
             return;

--- a/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
+++ b/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
@@ -17,7 +17,7 @@ class AzureMultiContainerBlobStorageTest extends FunctionalTestCase
 
     private $containers = [];
 
-    public function setUp()
+    protected function setUp()
     {
         $this->markTestSkipped(__CLASS__ . ' is flaky.');
 
@@ -247,7 +247,7 @@ class AzureMultiContainerBlobStorageTest extends FunctionalTestCase
         return $container;
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         foreach ($this->containers as $container) {
             $this->adapter->deleteContainer($container);

--- a/tests/Gaufrette/Functional/Adapter/CacheTest.php
+++ b/tests/Gaufrette/Functional/Adapter/CacheTest.php
@@ -8,7 +8,7 @@ use Gaufrette\Adapter\InMemory;
 
 class CacheTest extends FunctionalTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->filesystem = new Filesystem(new Cache(new InMemory(), new InMemory()));
     }

--- a/tests/Gaufrette/Functional/Adapter/DoctrineDbalTest.php
+++ b/tests/Gaufrette/Functional/Adapter/DoctrineDbalTest.php
@@ -11,7 +11,7 @@ class DoctrineDbalTest extends FunctionalTestCase
     /** @var  \Doctrine\DBAL\Connection */
     private $connection;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->connection = DriverManager::getConnection([
             'driver' => 'pdo_sqlite',
@@ -32,7 +32,7 @@ class DoctrineDbalTest extends FunctionalTestCase
         $this->filesystem = new Filesystem(new DoctrineDbal($this->connection, 'gaufrette'));
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $schemaManager = $this->connection->getSchemaManager();
 

--- a/tests/Gaufrette/Functional/Adapter/FtpTest.php
+++ b/tests/Gaufrette/Functional/Adapter/FtpTest.php
@@ -7,7 +7,7 @@ use Gaufrette\Filesystem;
 
 class FtpTest extends FunctionalTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $host = getenv('FTP_HOST');
         $port = getenv('FTP_PORT');
@@ -23,7 +23,7 @@ class FtpTest extends FunctionalTestCase
         $this->filesystem = new Filesystem($adapter);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         if (null === $this->filesystem) {
             return;

--- a/tests/Gaufrette/Functional/Adapter/FunctionalTestCase.php
+++ b/tests/Gaufrette/Functional/Adapter/FunctionalTestCase.php
@@ -25,7 +25,7 @@ abstract class FunctionalTestCase extends TestCase
         return $matches[1];
     }
 
-    public function setUp()
+    protected function setUp()
     {
         $basename = $this->getAdapterName();
         $filename = sprintf(
@@ -48,7 +48,7 @@ EOF
         $this->filesystem = new Filesystem($adapter);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         if (null === $this->filesystem) {
             return;

--- a/tests/Gaufrette/Functional/Adapter/GridFSTest.php
+++ b/tests/Gaufrette/Functional/Adapter/GridFSTest.php
@@ -8,7 +8,7 @@ use MongoDB\Client;
 
 class GridFSTest extends FunctionalTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $uri = getenv('MONGO_URI');
         $dbname = getenv('MONGO_DBNAME');
@@ -79,7 +79,7 @@ class GridFSTest extends FunctionalTestCase
      * @test
      * Tests metadata written to GridFS can be retrieved after writing
      */
-    public function testMetadataRetrieveAfterWrite()
+    public function shouldRetrieveMetadataAfterWrite()
     {
         //Create local copy of fileadapter
         $fileadpt = clone $this->filesystem->getAdapter();
@@ -94,7 +94,7 @@ class GridFSTest extends FunctionalTestCase
      * @test
      * Test to see if filesize works
      */
-    public function testSize()
+    public function shouldGetSize()
     {
         $this->filesystem->write('sizetest.txt', 'data');
         $this->assertEquals(4, $this->filesystem->size('sizetest.txt'));
@@ -104,7 +104,7 @@ class GridFSTest extends FunctionalTestCase
      * @test
      * Should retrieve empty metadata w/o errors
      */
-    public function testRetrieveWithoutMetadata()
+    public function shouldRetrieveEmptyMetadata()
     {
         $this->filesystem->write('no-metadata.txt', 'content');
 

--- a/tests/Gaufrette/Functional/Adapter/LocalTest.php
+++ b/tests/Gaufrette/Functional/Adapter/LocalTest.php
@@ -9,7 +9,7 @@ class LocalTest extends FunctionalTestCase
 {
     private $directory;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->directory = sprintf('%s/filesystem', str_replace('\\', '/', __DIR__));
 
@@ -20,7 +20,7 @@ class LocalTest extends FunctionalTestCase
         $this->filesystem = new Filesystem(new Local($this->directory));
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $adapter = $this->filesystem->getAdapter();
 

--- a/tests/Gaufrette/Functional/Adapter/MogileFSTest.php
+++ b/tests/Gaufrette/Functional/Adapter/MogileFSTest.php
@@ -5,6 +5,7 @@ namespace Gaufrette\Functional\Adapter;
 class MogileFSTest extends FunctionalTestCase
 {
     /**
+     * @test
      * @group functional
      */
     public function shouldGetMtime()
@@ -13,6 +14,7 @@ class MogileFSTest extends FunctionalTestCase
     }
 
     /**
+     * @test
      * @group functional
      */
     public function shouldGetMtimeNonExistingFile()

--- a/tests/Gaufrette/Functional/Adapter/OpenCloudTest.php
+++ b/tests/Gaufrette/Functional/Adapter/OpenCloudTest.php
@@ -14,7 +14,7 @@ class OpenCloudTest extends FunctionalTestCase
     /** @var string */
     private $container;
 
-    public function setUp()
+    protected function setUp()
     {
         $username = getenv('RACKSPACE_USER') ?: '';
         $apiKey = getenv('RACKSPACE_APIKEY') ?: '';
@@ -49,7 +49,7 @@ class OpenCloudTest extends FunctionalTestCase
         $this->filesystem = new Filesystem($adapter);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         if ($this->filesystem === null) {
             return;

--- a/tests/Gaufrette/Functional/Adapter/PhpseclibSftpTest.php
+++ b/tests/Gaufrette/Functional/Adapter/PhpseclibSftpTest.php
@@ -14,7 +14,7 @@ class PhpseclibSftpTest extends FunctionalTestCase
     /** @var string */
     private $baseDir;
 
-    public function setUp()
+    protected function setUp()
     {
         $host = getenv('SFTP_HOST');
         $port = getenv('SFTP_PORT') ?: 22;
@@ -34,7 +34,7 @@ class PhpseclibSftpTest extends FunctionalTestCase
         $this->filesystem = new Filesystem(new PhpseclibSftp($this->sftp, $this->baseDir, true));
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         if (!isset($this->sftp)) {
             return;

--- a/tests/Gaufrette/Functional/Adapter/SafeLocalTest.php
+++ b/tests/Gaufrette/Functional/Adapter/SafeLocalTest.php
@@ -7,7 +7,7 @@ use Gaufrette\Adapter\SafeLocal;
 
 class SafeLocalTest extends FunctionalTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         if (!file_exists($this->getDirectory())) {
             mkdir($this->getDirectory());
@@ -16,7 +16,7 @@ class SafeLocalTest extends FunctionalTestCase
         $this->filesystem = new Filesystem(new SafeLocal($this->getDirectory()));
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         foreach ($this->filesystem->keys() as $key) {
             $this->filesystem->delete($key);

--- a/tests/Gaufrette/Functional/Adapter/SftpTest.php
+++ b/tests/Gaufrette/Functional/Adapter/SftpTest.php
@@ -4,7 +4,7 @@ namespace Gaufrette\Functional\Adapter;
 
 class SftpTest extends FunctionalTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         if (!extension_loaded('ssh2')) {
             $this->markTestSkipped('Extension ssh2 not loaded');

--- a/tests/Gaufrette/Functional/Adapter/ZipTest.php
+++ b/tests/Gaufrette/Functional/Adapter/ZipTest.php
@@ -7,7 +7,7 @@ use Gaufrette\Filesystem;
 
 class ZipTest extends FunctionalTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         if (!extension_loaded('zip')) {
             return $this->markTestSkipped('The zip extension is not available.');
@@ -20,7 +20,7 @@ class ZipTest extends FunctionalTestCase
         $this->filesystem = new Filesystem(new Zip(__DIR__ . '/test.zip'));
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
 

--- a/tests/Gaufrette/Functional/FileStream/InMemoryBufferTest.php
+++ b/tests/Gaufrette/Functional/FileStream/InMemoryBufferTest.php
@@ -7,7 +7,7 @@ use Gaufrette\Adapter\InMemory as InMemoryAdapter;
 
 class InMemoryBufferTest extends FunctionalTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->filesystem = new Filesystem(new InMemoryAdapter([]));
 

--- a/tests/Gaufrette/Functional/FileStream/LocalTest.php
+++ b/tests/Gaufrette/Functional/FileStream/LocalTest.php
@@ -9,7 +9,7 @@ class LocalTest extends FunctionalTestCase
 {
     protected $directory;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->directory = __DIR__ . DIRECTORY_SEPARATOR . 'filesystem';
         @mkdir($this->directory . DIRECTORY_SEPARATOR . 'subdir', 0777, true);
@@ -19,7 +19,10 @@ class LocalTest extends FunctionalTestCase
         $this->registerLocalFilesystemInStream();
     }
 
-    public function testDirectoryChmod()
+    /**
+     * @test
+     */
+    public function shouldChmodDirectory()
     {
         if (strtolower(substr(PHP_OS, 0, 3)) === 'win') {
             $this->markTestSkipped('Chmod and umask are not available on Windows.');
@@ -32,7 +35,7 @@ class LocalTest extends FunctionalTestCase
         $this->assertEquals('0770', substr(sprintf('%o', $perms), -4));
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $adapter = $this->filesystem->getAdapter();
 


### PR DESCRIPTION
# Changed log
- According to the [PHPUnit fixtures reference](https://phpunit.de/manual/7.0/en/fixtures.html), the `setUp` and `tearDown` methods should be `protected`, not `public`.
- There're two approaches to mark test method on `PHPUnit` tests.
One is method name with `test` prefix. and another one is using `@test` comment annotation on specific method name.
To be consistency, let these methods be used with `prefix`.