### PR TITLE
Add MimeTypeProvider to AzureBlobStorage.

### DIFF
--- a/src/Gaufrette/Adapter/AzureBlobStorage.php
+++ b/src/Gaufrette/Adapter/AzureBlobStorage.php
@@ -20,7 +20,7 @@ use MicrosoftAzure\Storage\Common\Exceptions\ServiceException;
  * @author Luciano Mammino <lmammino@oryzone.com>
  * @author Paweł Czyżewski <pawel.czyzewski@enginewerk.com>
  */
-class AzureBlobStorage implements Adapter, MetadataSupporter, SizeCalculator, ChecksumCalculator
+class AzureBlobStorage implements Adapter, MetadataSupporter, SizeCalculator, ChecksumCalculator, MimeTypeProvider
 {
     /**
      * Error constants.
@@ -327,6 +327,25 @@ class AzureBlobStorage implements Adapter, MetadataSupporter, SizeCalculator, Ch
             return $properties->getProperties()->getContentLength();
         } catch (ServiceException $e) {
             $this->failIfContainerNotFound($e, sprintf('read content length for key "%s"', $key), $containerName);
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mimeType($key)
+    {
+        $this->init();
+        list($containerName, $key) = $this->tokenizeKey($key);
+
+        try {
+            $properties = $this->blobProxy->getBlobProperties($containerName, $key);
+
+            return $properties->getProperties()->getContentType();
+        } catch (ServiceException $e) {
+            $this->failIfContainerNotFound($e, sprintf('read content mime type for key "%s"', $key), $containerName);
 
             return false;
         }

--- a/tests/Gaufrette/Functional/Adapter/AzureBlobStorageTest.php
+++ b/tests/Gaufrette/Functional/Adapter/AzureBlobStorageTest.php
@@ -28,11 +28,24 @@ class AzureBlobStorageTest extends FunctionalTestCase
             $this->markTestSkipped('Either AZURE_ACCOUNT, AZURE_KEY and/or AZURE_CONTAINER env variables are not defined.');
         }
 
-        $connection = sprintf('BlobEndpoint=http://%1$s.blob.core.windows.net/;AccountName=%1$s;AccountKey=%2$s', $account, $key);
+        $connection = sprintf('BlobEndpoint=https://%1$s.blob.core.windows.net/;AccountName=%1$s;AccountKey=%2$s', $account, $key);
 
         $this->container = uniqid($containerName);
         $this->adapter = new AzureBlobStorage(new BlobProxyFactory($connection), $this->container, true);
         $this->filesystem = new Filesystem($this->adapter);
+    }
+
+    /**
+     * @test
+     * @group functional
+     */
+    public function shouldGetContentType()
+    {
+        $path = '/somefile';
+        $content = 'Some content';
+        $this->filesystem->write($path, $content);
+
+        $this->assertEquals("text/plain", $this->filesystem->mimeType($path));
     }
 
     protected function tearDown()

--- a/tests/Gaufrette/Functional/Adapter/AzureBlobStorageTest.php
+++ b/tests/Gaufrette/Functional/Adapter/AzureBlobStorageTest.php
@@ -45,7 +45,7 @@ class AzureBlobStorageTest extends FunctionalTestCase
         $content = 'Some content';
         $this->filesystem->write($path, $content);
 
-        $this->assertEquals("text/plain", $this->filesystem->mimeType($path));
+        $this->assertEquals('text/plain', $this->filesystem->mimeType($path));
     }
 
     protected function tearDown()

--- a/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
+++ b/tests/Gaufrette/Functional/Adapter/AzureMultiContainerBlobStorageTest.php
@@ -27,7 +27,7 @@ class AzureMultiContainerBlobStorageTest extends FunctionalTestCase
             $this->markTestSkipped('Either AZURE_ACCOUNT and/or AZURE_KEY env variables are not defined.');
         }
 
-        $connection = sprintf('BlobEndpoint=http://%1$s.blob.core.windows.net/;AccountName=%1$s;AccountKey=%2$s', $account, $key);
+        $connection = sprintf('BlobEndpoint=https://%1$s.blob.core.windows.net/;AccountName=%1$s;AccountKey=%2$s', $account, $key);
 
         $this->adapter = new AzureBlobStorage(new BlobProxyFactory($connection));
         $this->filesystem = new Filesystem($this->adapter);
@@ -120,6 +120,20 @@ class AzureMultiContainerBlobStorageTest extends FunctionalTestCase
         $this->filesystem->write($path, $content);
 
         $this->assertEquals(\md5($content), $this->filesystem->checksum($path));
+    }
+
+    /**
+     * @test
+     * @group functional
+     */
+    public function shouldGetContentType()
+    {
+        $path = $this->createUniqueContainerName('container') . '/foo';
+
+        $content = 'Some content';
+        $this->filesystem->write($path, $content);
+
+        $this->assertEquals('text/plain', $this->filesystem->mimeType($path));
     }
 
     /**


### PR DESCRIPTION
Also, fix Azure test cases by providing https URL.

Fixes #629 

The tests around Azure are marked as skipped, so I am not sure whether or not this should be removed, but I added the tests, and fixed test URLs to support https as otherwise, the test would fail.