### PR TITLE
Add tags support for S3 objects

### DIFF
--- a/src/Gaufrette/Adapter/AwsS3.php
+++ b/src/Gaufrette/Adapter/AwsS3.php
@@ -124,6 +124,11 @@ class AwsS3 implements Adapter, MetadataSupporter, ListKeysAware, SizeCalculator
     {
         $this->ensureBucketExists();
         $options = $this->getOptions($key, ['Body' => $content]);
+        
+        if (!empty($options['tags'])) {
+            $options['Tagging'] = http_build_query($options['tags']);
+            unset($options['tags']);
+        }
 
         /*
          * If the ContentType was not already set in the metadata, then we autodetect


### PR DESCRIPTION
Hello,

Problem: There is no easy way to add tags to S3 objects during upload :worried: 

Solution: I facilitated tag adding by transforming an array of tags into a query string (format supported by [AWS](https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#putobject)). :smile:

Ex: 
* Input: `['public' => 'yes', 'private' => 'no']`
* Output: `public=yes&private=no`

Can you tag the person who is in charge of AWS S3 ? I can't find him (his account no longer exist). :exclamation: 

@Nyholm

Have a great day!