### PR TITLE
:green_heart: Update PHP CS Fixer!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ composer.lock
 doc/.couscous
 .env
 .php_cs.cache
+.php-cs-fixer.cache
 phpunit.xml
 tests/adapters/*
 !tests/adapters/*.dist

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,6 +1,6 @@
 <?php
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setFinder(PhpCsFixer\Finder::create()
         ->exclude('vendor')
         ->in(__DIR__)
@@ -9,17 +9,17 @@ return PhpCsFixer\Config::create()
         '@PSR1' => true,
         '@PSR2' => true,
         'array_syntax' => [ 'syntax' => 'short' ],
-        'binary_operator_spaces' => [ 'align_equals' => false, 'align_double_arrow' => false ],
+        'binary_operator_spaces' => true,
         'blank_line_before_statement' => true,
         'cast_spaces' => true,
         'combine_consecutive_unsets' => true,
         'concat_space' => [ 'spacing' => 'one' ],
         'linebreak_after_opening_tag' => true,
-        'method_argument_space' => ['ensure_fully_multiline' => false],
+        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_break_comment' => false,
-        'no_extra_consecutive_blank_lines' => true,
+        'no_extra_blank_lines' => true,
         'no_spaces_around_offset' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unused_imports' => true,
@@ -34,7 +34,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_trim' => true,
         'single_quote' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
         'trim_array_spaces' => true,
     ])
     ->registerCustomFixers(new PedroTroller\CS\Fixer\Fixers())

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
     "require-dev": {
         "phpspec/phpspec": "^7.0",
         "phpunit/phpunit": "~8.0",
-        "mikey179/vfsstream": "v1.x-dev as 1.7.0"
+        "mikey179/vfsstream": "v1.x-dev as 1.7.0",
+        "friendsofphp/php-cs-fixer": "^3.9",
+        "pedrotroller/php-cs-custom-fixer": "^2.28"
     },
     "suggest": {
         "knplabs/knp-gaufrette-bundle": "to use with Symfony",

--- a/spec/Gaufrette/Adapter/AzureBlobStorage.php
+++ b/spec/Gaufrette/Adapter/AzureBlobStorage.php
@@ -155,8 +155,12 @@ class AzureBlobStorage extends ObjectBehavior
     function it_should_write_file($blobProxyFactory, $blobProxy)
     {
         $blobProxy
-            ->createBlockBlob('containerName', 'filename', 'some content',
-                \Mockery::type('\WindowsAzure\Blob\Models\CreateBlobOptions'))
+            ->createBlockBlob(
+                'containerName',
+                'filename',
+                'some content',
+                \Mockery::type('\WindowsAzure\Blob\Models\CreateBlobOptions')
+            )
             ->shouldBeCalled();
 
         $blobProxyFactory
@@ -174,8 +178,12 @@ class AzureBlobStorage extends ObjectBehavior
     function it_should_return_false_when_cannot_write($blobProxyFactory, $blobProxy)
     {
         $blobProxy
-            ->createBlockBlob('containerName', 'filename', 'some content',
-                \Mockery::type('\WindowsAzure\Blob\Models\CreateBlobOptions'))
+            ->createBlockBlob(
+                'containerName',
+                'filename',
+                'some content',
+                \Mockery::type('\WindowsAzure\Blob\Models\CreateBlobOptions')
+            )
             ->willThrow(new ServiceException(500));
 
         $blobProxyFactory
@@ -193,8 +201,12 @@ class AzureBlobStorage extends ObjectBehavior
     function it_should_not_mask_exception_when_write($blobProxyFactory, $blobProxy)
     {
         $blobProxy
-            ->createBlockBlob('containerName', 'filename', 'some content',
-                \Mockery::type('\WindowsAzure\Blob\Models\CreateBlobOptions'))
+            ->createBlockBlob(
+                'containerName',
+                'filename',
+                'some content',
+                \Mockery::type('\WindowsAzure\Blob\Models\CreateBlobOptions')
+            )
             ->willThrow(new \RuntimeException('write'));
 
         $blobProxyFactory

--- a/spec/Gaufrette/Adapter/DoctrineDbalSpec.php
+++ b/spec/Gaufrette/Adapter/DoctrineDbalSpec.php
@@ -78,7 +78,8 @@ class DoctrineDbalSpec extends ObjectBehavior
                     '"mtime"' => strtotime('2012-10-10 23:10:10'),
                     '"checksum"' => '9893532233caff98cd083a116b013c0b',
                     '"key"' => 'filename',
-                ])
+                ]
+            )
             ->shouldBeCalled();
 
         $this->write('filename', 'some content')->shouldReturn(12);
@@ -107,7 +108,8 @@ class DoctrineDbalSpec extends ObjectBehavior
                 ],
                 [
                     '"key"' => 'filename',
-                ])
+                ]
+            )
             ->shouldBeCalled();
 
         $this->write('filename', 'some content')->shouldReturn(12);
@@ -182,7 +184,8 @@ class DoctrineDbalSpec extends ObjectBehavior
                 ],
                 [
                     '"key"' => 'filename',
-                ])
+                ]
+            )
             ->shouldBeCalled()
             ->willReturn(1);
 

--- a/spec/Gaufrette/Adapter/OpenCloudSpec.php
+++ b/spec/Gaufrette/Adapter/OpenCloudSpec.php
@@ -180,13 +180,13 @@ class OpenCloudSpec extends ObjectBehavior
         $objects = [$object1, $object2, $object3];
 
         $objectList->next()->will(
-                   function () use ($objects, &$index) {
-                       if ($index < count($objects)) {
-                           $index++;
+            function () use ($objects, &$index) {
+                if ($index < count($objects)) {
+                    $index++;
 
-                           return $objects[$index - 1];
-                       }
-                   }
+                    return $objects[$index - 1];
+                }
+            }
         )          ->shouldBeCalledTimes(count($objects) + 1);
 
         $container->objectList()->willReturn($objectList);

--- a/spec/Gaufrette/Adapter/functions.php
+++ b/spec/Gaufrette/Adapter/functions.php
@@ -66,4 +66,3 @@ function apc_exists($path)
 
     return true;
 }
-

--- a/spec/Gaufrette/FileSpec.php
+++ b/spec/Gaufrette/FileSpec.php
@@ -6,7 +6,7 @@ use Gaufrette\Filesystem;
 use PhpSpec\ObjectBehavior;
 
 interface MetadataAdapter extends \Gaufrette\Adapter,
-                                  \Gaufrette\Adapter\MetadataSupporter
+    \Gaufrette\Adapter\MetadataSupporter
 {
 }
 

--- a/spec/Gaufrette/FilesystemSpec.php
+++ b/spec/Gaufrette/FilesystemSpec.php
@@ -8,11 +8,11 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 interface ExtendedAdapter extends \Gaufrette\Adapter,
-                          \Gaufrette\Adapter\FileFactory,
-                          \Gaufrette\Adapter\StreamFactory,
-                          \Gaufrette\Adapter\ChecksumCalculator,
-                          \Gaufrette\Adapter\MetadataSupporter,
-                          \Gaufrette\Adapter\MimeTypeProvider
+    \Gaufrette\Adapter\FileFactory,
+    \Gaufrette\Adapter\StreamFactory,
+    \Gaufrette\Adapter\ChecksumCalculator,
+    \Gaufrette\Adapter\MetadataSupporter,
+    \Gaufrette\Adapter\MimeTypeProvider
 {
 }
 

--- a/src/Gaufrette/Adapter/AsyncAwsS3.php
+++ b/src/Gaufrette/Adapter/AsyncAwsS3.php
@@ -280,7 +280,7 @@ class AsyncAwsS3 implements Adapter, MetadataSupporter, ListKeysAware, SizeCalcu
         $this->service->createBucket([
             'Bucket' => $this->bucket,
             'CreateBucketConfiguration' => [
-                'LocationConstraint' => $this->service->getConfiguration()->get(Configuration::OPTION_REGION)
+                'LocationConstraint' => $this->service->getConfiguration()->get(Configuration::OPTION_REGION),
             ],
         ]);
         $this->bucketExists = true;

--- a/src/Gaufrette/Adapter/DoctrineDbal.php
+++ b/src/Gaufrette/Adapter/DoctrineDbal.php
@@ -185,10 +185,12 @@ class DoctrineDbal implements Adapter, ChecksumCalculator, ListKeysAware
 
         return [
             'dirs' => [],
-            'keys' => array_map(function ($value) {
+            'keys' => array_map(
+                function ($value) {
                 return $value['_key'];
             },
-                $keys),
+                $keys
+            ),
         ];
     }
 

--- a/src/Gaufrette/Adapter/Zip.php
+++ b/src/Gaufrette/Adapter/Zip.php
@@ -163,46 +163,46 @@ class Zip implements Adapter
 
         if (true !== ($resultCode = $this->zipArchive->open($this->zipFile, ZipArchive::CREATE))) {
             switch ($resultCode) {
-            case ZipArchive::ER_EXISTS:
-                $errMsg = 'File already exists.';
+                case ZipArchive::ER_EXISTS:
+                    $errMsg = 'File already exists.';
 
-                break;
-            case ZipArchive::ER_INCONS:
-                $errMsg = 'Zip archive inconsistent.';
+                    break;
+                case ZipArchive::ER_INCONS:
+                    $errMsg = 'Zip archive inconsistent.';
 
-                break;
-            case ZipArchive::ER_INVAL:
-                $errMsg = 'Invalid argument.';
+                    break;
+                case ZipArchive::ER_INVAL:
+                    $errMsg = 'Invalid argument.';
 
-                break;
-            case ZipArchive::ER_MEMORY:
-                $errMsg = 'Malloc failure.';
+                    break;
+                case ZipArchive::ER_MEMORY:
+                    $errMsg = 'Malloc failure.';
 
-                break;
-            case ZipArchive::ER_NOENT:
-                $errMsg = 'Invalid argument.';
+                    break;
+                case ZipArchive::ER_NOENT:
+                    $errMsg = 'Invalid argument.';
 
-                break;
-            case ZipArchive::ER_NOZIP:
-                $errMsg = 'Not a zip archive.';
+                    break;
+                case ZipArchive::ER_NOZIP:
+                    $errMsg = 'Not a zip archive.';
 
-                break;
-            case ZipArchive::ER_OPEN:
-                $errMsg = 'Can\'t open file.';
+                    break;
+                case ZipArchive::ER_OPEN:
+                    $errMsg = 'Can\'t open file.';
 
-                break;
-            case ZipArchive::ER_READ:
-                $errMsg = 'Read error.';
+                    break;
+                case ZipArchive::ER_READ:
+                    $errMsg = 'Read error.';
 
-                break;
-            case ZipArchive::ER_SEEK:
-                $errMsg = 'Seek error.';
+                    break;
+                case ZipArchive::ER_SEEK:
+                    $errMsg = 'Seek error.';
 
-                break;
-            default:
-                $errMsg = 'Unknown error.';
+                    break;
+                default:
+                    $errMsg = 'Unknown error.';
 
-                break;
+                    break;
             }
 
             throw new \RuntimeException(sprintf('%s', $errMsg));

--- a/tests/Gaufrette/Functional/Adapter/DoctrineDbalTest.php
+++ b/tests/Gaufrette/Functional/Adapter/DoctrineDbalTest.php
@@ -72,30 +72,50 @@ class DoctrineDbalTest extends FunctionalTestCase
         $this->assertEquals(
             $this->filesystem->keys(),
             $keys['keys'],
-            '', 0, 10, true);
+            '',
+            0,
+            10,
+            true
+        );
 
         $keys = $this->filesystem->listKeys('foo/foob');
         $this->assertEquals(
             ['foo/foobar/bar.txt'],
             $keys['keys'],
-            '', 0, 10, true);
+            '',
+            0,
+            10,
+            true
+        );
 
         $keys = $this->filesystem->listKeys('foo/');
         $this->assertEquals(
             ['foo/foobar/bar.txt', 'foo/bar/buzz.txt'],
             $keys['keys'],
-            '', 0, 10, true);
+            '',
+            0,
+            10,
+            true
+        );
 
         $keys = $this->filesystem->listKeys('foo');
         $this->assertEquals(
             ['foo/foobar/bar.txt', 'foo/bar/buzz.txt', 'foobarbuz.txt', 'foo'],
             $keys['keys'],
-            '', 0, 10, true);
+            '',
+            0,
+            10,
+            true
+        );
 
         $keys = $this->filesystem->listKeys('fooz');
         $this->assertEquals(
             [],
             $keys['keys'],
-            '', 0, 10, true);
+            '',
+            0,
+            10,
+            true
+        );
     }
 }

--- a/tests/Gaufrette/Functional/Adapter/FunctionalTestCase.php
+++ b/tests/Gaufrette/Functional/Adapter/FunctionalTestCase.php
@@ -36,7 +36,8 @@ abstract class FunctionalTestCase extends TestCase
         );
 
         if (!file_exists($filename)) {
-            $this->markTestSkipped(<<<EOF
+            $this->markTestSkipped(
+                <<<EOF
 To run the {$basename} filesystem tests, you must:
 
  1. Copy the file "{$filename}.dist" as "{$filename}"

--- a/tests/Gaufrette/Functional/Adapter/GridFSTest.php
+++ b/tests/Gaufrette/Functional/Adapter/GridFSTest.php
@@ -48,31 +48,51 @@ class GridFSTest extends FunctionalTestCase
         $this->assertEquals(
             $this->filesystem->keys(),
             $keys['keys'],
-            '', 0, 10, true);
+            '',
+            0,
+            10,
+            true
+        );
 
         $keys = $this->filesystem->listKeys('foo/foob');
         $this->assertEquals(
             ['foo/foobar/bar.txt'],
             $keys['keys'],
-            '', 0, 10, true);
+            '',
+            0,
+            10,
+            true
+        );
 
         $keys = $this->filesystem->listKeys('foo/');
         $this->assertEquals(
             ['foo/foobar/bar.txt', 'foo/bar/buzz.txt'],
             $keys['keys'],
-            '', 0, 10, true);
+            '',
+            0,
+            10,
+            true
+        );
 
         $keys = $this->filesystem->listKeys('foo');
         $this->assertEquals(
             ['foo/foobar/bar.txt', 'foo/bar/buzz.txt', 'foobarbuz.txt', 'foo'],
             $keys['keys'],
-            '', 0, 10, true);
+            '',
+            0,
+            10,
+            true
+        );
 
         $keys = $this->filesystem->listKeys('fooz');
         $this->assertEquals(
             [],
             $keys['keys'],
-            '', 0, 10, true);
+            '',
+            0,
+            10,
+            true
+        );
     }
 
     /**


### PR DESCRIPTION
Upgrading PHP CS Fixer is required for supporting PHP 8.1. I add it as a dependency because it uses pedrotroller/php-cs-custom-fixer and I will just keep it because after all, we're in knp world :) .