### PR TITLE
:white_check_mark: Fix Azure blob storage tests

### DIFF
--- a/tests/Gaufrette/Functional/Adapter/AzureBlobStorageTest.php
+++ b/tests/Gaufrette/Functional/Adapter/AzureBlobStorageTest.php
@@ -28,7 +28,7 @@ class AzureBlobStorageTest extends FunctionalTestCase
             $this->markTestSkipped('Either AZURE_ACCOUNT, AZURE_KEY and/or AZURE_CONTAINER env variables are not defined.');
         }
 
-        $connection = sprintf('BlobEndpoint=https://%1$s.blob.core.windows.net/;AccountName=%1$s;AccountKey=%2$s', $account, $key);
+        $connection = sprintf('DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=core.windows.net', $account, $key);
 
         $this->container = uniqid($containerName);
         $this->adapter = new AzureBlobStorage(new BlobProxyFactory($connection), $this->container, true);


### PR DESCRIPTION
It still triggers a lot of warnings because the SDK of Microsoft is not 100% compatible with PHP 8.1, see those PR:
- https://github.com/Azure/azure-storage-php/pull/341
- https://github.com/Azure/azure-storage-php/pull/340

Still working on making everything green for PHP 8+ 😄 . Feel free to send love.