### PR TITLE
:bug: Fix infinite loop in ftp adapter (php 8.1)

### DIFF
--- a/src/Gaufrette/Adapter/Ftp.php
+++ b/src/Gaufrette/Adapter/Ftp.php
@@ -490,6 +490,10 @@ class Ftp implements Adapter, FileFactory, ListKeysAware, SizeCalculator
      */
     private function isConnected()
     {
+        if (class_exists('\FTP\Connection')) {
+            return $this->connection instanceof \FTP\Connection;
+        }
+
         return is_resource($this->connection);
     }
 


### PR DESCRIPTION
The connection is not a resource anymore in PHP 8.1, `isConnected()` was not resulting in the correct output anymore.

Still working on making everything green for PHP 8+ 😄 . Feel free to send love.