### PR TITLE
👽 Fix Google Cloud Storage adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ phpunit.xml
 tests/adapters/*
 !tests/adapters/*.dist
 vendor/
+tests/Gaufrette/Functional/adapters/*.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+v0.11.0
+=======
+
+## Added
+
+- Google Cloud Storage: options to automatically create bucket if not exists
+
 v0.10.0
 =======
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ docker.all-deps: docker.deps ## Install dependencies
 	docker/run-task php${PHP_VERSION} composer require --no-update \
 		aws/aws-sdk-php:^3.158 \
 		rackspace/php-opencloud:^1.9.2 \
-		google/apiclient:^1.1.3 \
+		google/apiclient:^2.12 \
 		doctrine/dbal:^2.3 \
 		league/flysystem:^1.0 \
 		microsoft/azure-storage-blob:^1.0 \

--- a/tests/Gaufrette/Functional/Adapter/GoogleCloudStorageTest.php
+++ b/tests/Gaufrette/Functional/Adapter/GoogleCloudStorageTest.php
@@ -2,6 +2,8 @@
 
 namespace Gaufrette\Functional\Adapter;
 
+use Gaufrette\Adapter\GoogleCloudStorage;
+
 /**
  * Functional tests for the GoogleCloudStorage adapter.
  *
@@ -15,18 +17,16 @@ class GoogleCloudStorageTest extends FunctionalTestCase
     /**
      * @test
      * @group functional
-     *
-     * @expectedException \RuntimeException
      */
     public function shouldThrowExceptionIfBucketMissing()
     {
+        $this->expectException(\RuntimeException::class);
         /** @var \Gaufrette\Adapter\GoogleCloudStorage $adapter */
         $adapter = $this->filesystem->getAdapter();
-        $oldBucket = $adapter->getOptions();
+        $adapter->setOptions([GoogleCloudStorage::OPTION_CREATE_BUCKET_IF_NOT_EXISTS => false]);
         $adapter->setBucket('Gaufrette-' . mt_rand());
 
         $adapter->read('foo');
-        $adapter->setBucket($oldBucket);
     }
 
     /**

--- a/tests/Gaufrette/Functional/adapters/GoogleCloudStorage.php.dist
+++ b/tests/Gaufrette/Functional/adapters/GoogleCloudStorage.php.dist
@@ -1,23 +1,28 @@
 <?php
 
-$client_id = 'xxxxxxxxxxxxxxx.apps.googleusercontent.com';
-$service_account_name = 'xxxxxxxxxxxxxxx@developer.gserviceaccount.com';
-$key_file_location = 'key.p12';
-$bucket_name = 'mybucket';
+use Gaufrette\Adapter\GoogleCloudStorage;
 
-$client = new \Google_Client();
+$keyFileLocation = '/home/me/path/to/service-auth-key.json';
+$bucketName = 'gaufrette-bucket-test-' . uniqid();
+$projectId = 'your-project-id-000';
+$bucketLocation = 'EUROPE-WEST9';
+
+putenv('GOOGLE_APPLICATION_CREDENTIALS=' . $keyFileLocation);
+
+$client = new \Google\Client();
 $client->setApplicationName('Gaufrette');
+$client->addScope(Google\Service\Storage::DEVSTORAGE_FULL_CONTROL);
+$client->useApplicationDefaultCredentials();
 
-$key = file_get_contents($key_file_location);
-$cred = new \Google_Auth_AssertionCredentials(
-    $service_account_name,
-    array(\Google_Service_Storage::DEVSTORAGE_FULL_CONTROL),
-    $key
+$service = new \Google\Service\Storage($client);
+
+return new GoogleCloudStorage(
+    $service,
+    $bucketName,
+    [
+        GoogleCloudStorage::OPTION_CREATE_BUCKET_IF_NOT_EXISTS => true,
+        GoogleCloudStorage::OPTION_PROJECT_ID => $projectId,
+        GoogleCloudStorage::OPTION_LOCATION => $bucketLocation,
+    ],
+    true
 );
-$client->setAssertionCredentials($cred);
-if ($client->getAuth()->isAccessTokenExpired()) {
-    $client->getAuth()->refreshTokenWithAssertion($cred);
-}
-
-$service = new \Google_Service_Storage($client);
-return new Gaufrette\Adapter\GoogleCloudStorage($service, $bucket_name, array(), true);


### PR DESCRIPTION
This is mostly an adaptation to the new Google version of the SDK of Google. (please notice this library will probably be abandoned since google documents another one)

Beware using this adapter that it is not fully compatible with PHP 8.1... Probably because Google recommends another library. But for now, you're just getting deprecation notices that you can ignore.

This PR also adds a missing feature and fixes a bug:
- The adapter now accepts options to create automatically a bucket if it does not exists
- If the bundle name changes, the bucket detection is reset (not working previously)

I am still working on making everything green for PHP 8+ 😄 . Feel free to send love.