### PR TITLE
Fixed azure blob write method

### DIFF
--- a/src/Gaufrette/Adapter/AzureBlobStorage.php
+++ b/src/Gaufrette/Adapter/AzureBlobStorage.php
@@ -198,6 +198,11 @@ class AzureBlobStorage implements Adapter, MetadataSupporter, SizeCalculator, Ch
             $options->setContentType($contentType);
         }
 
+        $size = is_resource($content)
+            ? Util\Size::fromResource($content)
+            : Util\Size::fromContent($content)
+        ;
+
         try {
             if ($this->multiContainerMode) {
                 $this->createContainer($containerName);
@@ -209,11 +214,8 @@ class AzureBlobStorage implements Adapter, MetadataSupporter, SizeCalculator, Ch
 
             return false;
         }
-        if (is_resource($content)) {
-            return Util\Size::fromResource($content);
-        }
 
-        return Util\Size::fromContent($content);
+        return $size;
     }
 
     /**


### PR DESCRIPTION
Fixed: when write function is executed with resource instead of string it fail because stream is already closed when using is_resource;