### PR TITLE
Resolved creation of dynamic property Gaufrette\StreamWrapper:: is de…

### DIFF
--- a/src/Gaufrette/StreamWrapper.php
+++ b/src/Gaufrette/StreamWrapper.php
@@ -10,6 +10,9 @@ namespace Gaufrette;
  */
 class StreamWrapper
 {
+    /** @var resource|null Stream context (this is set by PHP) */
+    public $context;
+    
     private static $filesystemMap;
 
     private $stream;


### PR DESCRIPTION
I'm using the knplabs/knp-gaufrette-bundle:v0.8.0 library

Since I have upgraded php version from 8.1 to 8.2 I am getting a deprecated warning "Deprecated: Creation of dynamic property Gaufrette\StreamWrapper::$context is deprecated in .../vendor/symfony/http-foundation/BinaryFileResponse.php on line 199" when returning the file in a controller:

`return new BinaryFileResponse('gaufrette://foo/hello.txt');`

I've added the public context property to the GaufretteStreamWrapper object as per the native class specification in php:

https://www.php.net/streamwrapper

With this change the code works perfectly, as it does not access the $context property dynamically.

If you think it is convenient I would like to add this change to the library.

Thanks