### PR TITLE
Add `tests` and `docker` folders in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,5 @@
 /psalm.xml export-ignore
 /bin export-ignore
 /doc export-ignore
+/docker export-ignore
+/tests export-ignore


### PR DESCRIPTION
Hello,

This PR add `tests` and `docker` folder in .gitattributes in order to reduce vendor size

![image](https://github.com/KnpLabs/Gaufrette/assets/9253091/618b87fe-0bb6-45ad-84dd-c213a751d3df)
