### PR TITLE
Declare StreamWrapper::context explicitly to avoid dynamic property

### DIFF
--- a/src/Gaufrette/StreamWrapper.php
+++ b/src/Gaufrette/StreamWrapper.php
@@ -10,6 +10,14 @@ namespace Gaufrette;
  */
 class StreamWrapper
 {
+    /**
+     * Required to avoid creating a dynamic property,
+     * see https://www.php.net/manual/en/class.streamwrapper.php.
+     *
+     * @var resource
+     */
+    public $context;
+
     private static $filesystemMap;
 
     private $stream;


### PR DESCRIPTION
Under PHP 8.2, the following deprecation warning occurs when using the stream wrapper implementation.

```
Deprecated: Creation of dynamic property Gaufrette\StreamWrapper::$context is deprecated
```