### PR TITLE
chore: make nullable parameter explicit

### DIFF
--- a/src/Gaufrette/Exception/FileAlreadyExists.php
+++ b/src/Gaufrette/Exception/FileAlreadyExists.php
@@ -13,7 +13,7 @@ class FileAlreadyExists extends \RuntimeException implements Exception
 {
     private $key;
 
-    public function __construct($key, $code = 0, \Exception $previous = null)
+    public function __construct($key, $code = 0, ?\Exception $previous = null)
     {
         $this->key = $key;
 

--- a/src/Gaufrette/Exception/FileNotFound.php
+++ b/src/Gaufrette/Exception/FileNotFound.php
@@ -13,7 +13,7 @@ class FileNotFound extends \RuntimeException implements Exception
 {
     private $key;
 
-    public function __construct($key, $code = 0, \Exception $previous = null)
+    public function __construct($key, $code = 0, ?\Exception $previous = null)
     {
         $this->key = $key;
 

--- a/src/Gaufrette/Exception/UnexpectedFile.php
+++ b/src/Gaufrette/Exception/UnexpectedFile.php
@@ -13,7 +13,7 @@ class UnexpectedFile extends \RuntimeException implements Exception
 {
     private $key;
 
-    public function __construct($key, $code = 0, \Exception $previous = null)
+    public function __construct($key, $code = 0, ?\Exception $previous = null)
     {
         $this->key = $key;
 


### PR DESCRIPTION
fix errors like :
```
Gaufrette\Exception\FileNotFound::__construct(): Implicitly marking parameter $previous as nullable is deprecated
```